### PR TITLE
feat: 親状態が異なる子状態で同一IDを許容（ISSUE-051）

### DIFF
--- a/stablestate.html
+++ b/stablestate.html
@@ -5066,18 +5066,18 @@ document.addEventListener('keydown', function(e) {
   const ta = document.getElementById('editor');
   const ae = document.activeElement;
 
-  // Ctrl+Z: Undo (always works)
+  // Don't intercept while editing DSL or other form fields (let native undo/redo etc. work)
+  if (ae === ta) return;
+  if (ae && (ae.tagName === 'INPUT' || ae.tagName === 'SELECT' || ae.tagName === 'TEXTAREA')) {
+    return;
+  }
+
+  // Ctrl+Z: Undo (app-level)
   if ((e.ctrlKey || e.metaKey) && e.key === 'z' && !e.shiftKey) { e.preventDefault(); undo(); return; }
   // Ctrl+Y or Ctrl+Shift+Z: Redo
   if ((e.ctrlKey || e.metaKey) && (e.key === 'y' || (e.key === 'z' && e.shiftKey))) { e.preventDefault(); redo(); return; }
   // Ctrl+Shift+Z uppercase fallback
   if ((e.ctrlKey || e.metaKey) && e.key === 'Z' && e.shiftKey) { e.preventDefault(); redo(); return; }
-
-  // Don't intercept while editing DSL
-  if (ae === ta) return;
-  if (ae && (ae.tagName === 'INPUT' || ae.tagName === 'SELECT' || ae.tagName === 'TEXTAREA')) {
-    return;
-  }
 
   // Ctrl+C: Copy
   if ((e.ctrlKey || e.metaKey) && e.key === 'c') { e.preventDefault(); copySelection(); return; }

--- a/stablestate.html
+++ b/stablestate.html
@@ -326,9 +326,11 @@ function resolveSelType(id) {
 // Build dot-path reference for a state/pseudo (e.g. "active.accel")
 function stateDotPath(id) {
   if (!parsed) return id;
+  // Try direct path lookup first (id might already be a path)
   const el = parsed.stateMap[id] || parsed.pseudoMap[id];
+  if (el && el.path) return el.path;
   if (!el || !el.parent) return id;
-  // Walk up parent chain
+  // Walk up parent chain (fallback for pseudo-states without path)
   const parts = [id];
   let pid = el.parent;
   while (pid) {
@@ -515,8 +517,8 @@ function parseDSL(text) {
       } else {
         // Parse trailing props on the closing brace line: } entry=Foo exit=Bar
         const afterBrace = trimmed.slice(1).trim();
-        if (afterBrace && result.stateMap[popped.id]) {
-          parseProps(afterBrace, result.stateMap[popped.id]);
+        if (afterBrace && result.stateMap[popped.path || popped.id]) {
+          parseProps(afterBrace, result.stateMap[popped.path || popped.id]);
         }
       }
       continue;
@@ -604,15 +606,26 @@ function parseDSL(text) {
     const stateMatch = trimmed.match(/^state\s+(\S+)\s+"([^"]*)"\s+at\s+(-?[\d.]+)\s*,\s*(-?[\d.]+)\s+size\s+(-?[\d.]+)\s*x\s*(-?[\d.]+)(.*)$/);
     if (stateMatch) {
       const id = stateMatch[1];
-      if (checkDuplicate(id, lineNum, result)) continue;
       const rest = stateMatch[7].trim();
       // Check if composite (ends with {)
       const isComposite = rest.endsWith('{');
       const propsStr = isComposite ? rest.slice(0, -1).trim() : rest;
 
+      const parentEntry = nestingStack.length > 0 ? nestingStack.findLast(e => e.type === 'state') : null;
+      const parentId = parentEntry ? parentEntry.id : null;
+      const parentPath = parentEntry ? parentEntry.path : null;
+      const path = parentPath ? parentPath + '.' + id : id;
+
+      // Check duplicate by path (allows same bare ID under different parents)
+      if (result.stateMap[path]) {
+        result.errors.push({ line: lineNum, msg: 'Duplicate state path: ' + path });
+        continue;
+      }
+
       const st = {
         type: 'state',
         id: id,
+        path: path,
         label: stateMatch[2],
         x: parseFloat(stateMatch[3]),
         y: parseFloat(stateMatch[4]),
@@ -626,7 +639,8 @@ function parseDSL(text) {
         entry: null,
         do: null,
         exit: null,
-        parent: nestingStack.length > 0 ? nestingStack.findLast(e => e.type === 'state')?.id || null : null,
+        parent: parentId,
+        parentPath: parentPath,
         region: currentRegion,
         children: [],
         isInitial: false,
@@ -637,16 +651,18 @@ function parseDSL(text) {
       if (propsStr) parseProps(propsStr, st);
 
       result.states.push(st);
-      result.stateMap[id] = st;
+      result.stateMap[path] = st;
+      // Also register bare ID for backward compatibility (overwritten if duplicate)
+      if (!result.stateMap[id]) result.stateMap[id] = st;
 
       // Add to parent's children
-      if (st.parent && result.stateMap[st.parent]) {
-        result.stateMap[st.parent].children.push(id);
+      if (parentPath && result.stateMap[parentPath]) {
+        result.stateMap[parentPath].children.push(path);
       }
 
       // Push onto nesting stack if composite
       if (isComposite) {
-        nestingStack.push({ type: 'state', id: id });
+        nestingStack.push({ type: 'state', id: id, path: path });
       }
       continue;
     }

--- a/stablestate.html
+++ b/stablestate.html
@@ -808,6 +808,9 @@ function parseDSL(text) {
     result.errors.push({ line: lines.length, msg: 'Unclosed composite state: ' + nestingStack.join(', ') });
   }
 
+  console.log('[parseDSL] states:', result.states.map(s => ({id: s.id, path: s.path, parent: s.parent, line: s.line})));
+  console.log('[parseDSL] stateMap keys:', Object.keys(result.stateMap));
+  console.log('[parseDSL] errors:', result.errors);
   return result;
 }
 
@@ -4391,7 +4394,8 @@ function removeDSLElement(id, dsl, lineNum) {
 }
 
 function deleteSelected() {
-  if (!sel.length) return;
+  console.log('[deleteSelected] sel=', JSON.stringify(sel));
+  if (!sel.length) { console.log('[deleteSelected] sel empty'); return; }
   pushHistory();
   // Sort by line number descending to avoid line shift issues
   const items = sel.map(si => {

--- a/stablestate.html
+++ b/stablestate.html
@@ -999,13 +999,40 @@ function updatePos(type, id, nx, ny, dsl, lineNum) {
 }
 
 // Update size (size WxH) for a given element type and id
-function updateSize(type, id, nw, nh, dsl) {
+function updateSize(type, id, nw, nh, dsl, lineNum) {
+  if (lineNum != null) {
+    const lines = dsl.split('\n');
+    const idx = lineNum - 1;
+    if (idx >= 0 && idx < lines.length) {
+      const re = new RegExp(`^(\\s*${type}\\s+${id}\\s+.*\\bsize\\s+)[\\d.]+x[\\d.]+(.*$)`);
+      lines[idx] = lines[idx].replace(re, `$1${nw}x${nh}$2`);
+    }
+    return lines.join('\n');
+  }
   const re = new RegExp(`^(\\s*${type}\\s+${id}\\s+.*\\bsize\\s+)[\\d.]+x[\\d.]+(.*$)`, 'm');
   return dsl.replace(re, `$1${nw}x${nh}$2`);
 }
 
 // Add or replace a property (key=value) on an element line
-function updateProp(type, id, prop, val, dsl) {
+function updateProp(type, id, prop, val, dsl, lineNum) {
+  if (lineNum != null) {
+    const lines = dsl.split('\n');
+    const idx = lineNum - 1;
+    if (idx >= 0 && idx < lines.length) {
+      const reExist = new RegExp(`^(\\s*${type}\\s+${id}\\s+.*)\\b${prop}=\\S+(.*$)`);
+      if (reExist.test(lines[idx])) {
+        lines[idx] = lines[idx].replace(reExist, `$1${prop}=${val}$2`);
+      } else {
+        const trimEnd = lines[idx].trimEnd();
+        if (trimEnd.endsWith('{')) {
+          lines[idx] = trimEnd.slice(0, -1).trimEnd() + ` ${prop}=${val} {`;
+        } else {
+          lines[idx] = trimEnd + ` ${prop}=${val}`;
+        }
+      }
+    }
+    return lines.join('\n');
+  }
   // First try to replace existing prop
   const reExist = new RegExp(`^(\\s*${type}\\s+${id}\\s+.*)\\b${prop}=\\S+(.*$)`, 'm');
   if (reExist.test(dsl)) {
@@ -1023,7 +1050,16 @@ function updateProp(type, id, prop, val, dsl) {
 }
 
 // Change the quoted label for an element
-function updateLabel(type, id, newLabel, dsl) {
+function updateLabel(type, id, newLabel, dsl, lineNum) {
+  if (lineNum != null) {
+    const lines = dsl.split('\n');
+    const idx = lineNum - 1;
+    if (idx >= 0 && idx < lines.length) {
+      const re = new RegExp(`^(\\s*${type}\\s+${id}\\s+)"[^"]*"(.*)$`);
+      lines[idx] = lines[idx].replace(re, `$1"${newLabel}"$2`);
+    }
+    return lines.join('\n');
+  }
   const re = new RegExp(`^(\\s*${type}\\s+${id}\\s+)"[^"]*"(.*)$`, 'm');
   return dsl.replace(re, `$1"${newLabel}"$2`);
 }
@@ -3195,11 +3231,15 @@ function renderProps() {
   function getElTypeAndId() {
     if (selArr.length !== 1) return null;
     const id = selArr[0];
-    if (parsed.stateMap[id]) return { type: 'state', id };
-    if (parsed.pseudoMap[id]) return { type: parsed.pseudoMap[id].type, id };
-    if (parsed.groupMap[id]) return { type: 'group', id };
-    if (parsed.noteMap[id]) return { type: 'note', id };
-    return null;
+    const el = parsed.stateMap[id] || parsed.pseudoMap[id] || parsed.groupMap[id] || parsed.noteMap[id];
+    if (!el) return null;
+    let type;
+    if (parsed.stateMap[id]) type = 'state';
+    else if (parsed.pseudoMap[id]) type = parsed.pseudoMap[id].type;
+    else if (parsed.groupMap[id]) type = 'group';
+    else if (parsed.noteMap[id]) type = 'note';
+    else return null;
+    return { type, id: el.id, line: el.line };
   }
 
   // Label change
@@ -3208,7 +3248,7 @@ function renderProps() {
     if (!info) return;
     pushHistory();
     let dsl = getDsl();
-    dsl = updateLabel(info.type, info.id, this.value, dsl);
+    dsl = updateLabel(info.type, info.id, this.value, dsl, info.line);
     setDsl(dsl);
     refreshView();
   });
@@ -3220,7 +3260,7 @@ function renderProps() {
     if (!info) return;
     pushHistory();
     let dsl = getDsl();
-    dsl = updateLabel(info.type, info.id, this.value.replace(/\n/g, '\\n'), dsl);
+    dsl = updateLabel(info.type, info.id, this.value.replace(/\n/g, '\\n'), dsl, info.line);
     setDsl(dsl);
     refreshView();
   });
@@ -3235,7 +3275,7 @@ function renderProps() {
     let dsl = getDsl();
     const nx = parseFloat(document.getElementById('pp-x').value) || 0;
     const ny = parseFloat(document.getElementById('pp-y').value) || 0;
-    dsl = updatePos(info.type, info.id, nx, ny, dsl);
+    dsl = updatePos(info.type, info.id, nx, ny, dsl, info.line);
     setDsl(dsl);
     refreshView();
   }
@@ -3252,7 +3292,7 @@ function renderProps() {
     let dsl = getDsl();
     const nw = parseFloat(document.getElementById('pp-w').value) || 1;
     const nh = parseFloat(document.getElementById('pp-h').value) || 1;
-    dsl = updateSize(info.type, info.id, nw, nh, dsl);
+    dsl = updateSize(info.type, info.id, nw, nh, dsl, info.line);
     setDsl(dsl);
     refreshView();
   }
@@ -3268,7 +3308,7 @@ function renderProps() {
       let dsl = getDsl();
       const val = this.value.trim();
       if (val) {
-        dsl = updateProp(info.type, info.id, field, val, dsl);
+        dsl = updateProp(info.type, info.id, field, val, dsl, info.line);
       } else {
         // Remove the property by replacing with empty — use regex to strip
         const re = new RegExp(`(^\\s*${info.type}\\s+${info.id}\\s+.*)\\b${field}=\\S+`, 'm');
@@ -3286,7 +3326,7 @@ function renderProps() {
       if (!info) return;
       pushHistory();
       let dsl = getDsl();
-      dsl = updateProp(info.type, info.id, this.dataset.prop, this.dataset.val, dsl);
+      dsl = updateProp(info.type, info.id, this.dataset.prop, this.dataset.val, dsl, info.line);
       setDsl(dsl);
       refresh();
     });
@@ -3300,7 +3340,7 @@ function renderProps() {
     let dsl = getDsl();
     const val = this.value.trim();
     if (val) {
-      dsl = updateProp(info.type, info.id, 'border', val, dsl);
+      dsl = updateProp(info.type, info.id, 'border', val, dsl, info.line);
     } else {
       const re = new RegExp(`(^\\s*${info.type}\\s+${info.id}\\s+.*)\\bborder=\\S+`, 'm');
       dsl = dsl.replace(re, '$1');
@@ -3317,7 +3357,7 @@ function renderProps() {
     let dsl = getDsl();
     const val = this.value.trim();
     if (val) {
-      dsl = updateProp(info.type, info.id, 'text', val, dsl);
+      dsl = updateProp(info.type, info.id, 'text', val, dsl, info.line);
     } else {
       const re = new RegExp(`(^\\s*${info.type}\\s+${info.id}\\s+.*)\\btext=\\S+`, 'm');
       dsl = dsl.replace(re, '$1');
@@ -3334,7 +3374,7 @@ function renderProps() {
     let dsl = getDsl();
     const val = this.value;
     if (val) {
-      dsl = updateProp(info.type, info.id, 'style', val, dsl);
+      dsl = updateProp(info.type, info.id, 'style', val, dsl, info.line);
     } else {
       const re = new RegExp(`(^\\s*${info.type}\\s+${info.id}\\s+.*)\\bstyle=\\S+`, 'm');
       dsl = dsl.replace(re, '$1');
@@ -3351,7 +3391,7 @@ function renderProps() {
     let dsl = getDsl();
     const val = this.value.trim();
     if (val) {
-      dsl = updateProp(info.type, info.id, 'round', val, dsl);
+      dsl = updateProp(info.type, info.id, 'round', val, dsl, info.line);
     } else {
       const re = new RegExp(`(^\\s*${info.type}\\s+${info.id}\\s+.*)\\bround=\\S+`, 'm');
       dsl = dsl.replace(re, '$1');

--- a/stablestate.html
+++ b/stablestate.html
@@ -2634,6 +2634,8 @@ function renderTable(parsed) {
       const isStateField = (field === 'entry' || field === 'do' || field === 'exit');
       const isAction = isStateField || field === 'action';
       const st = parsed.stateMap[stateId];
+      const stBareId = st ? st.id : stateId;
+      const stLine = st ? st.line : null;
       const stLabel = st ? st.label : stateId;
 
       let html = `<div class="prop-section"><div class="prop-label">${esc(stLabel)}</div>`;
@@ -2650,8 +2652,13 @@ function renderTable(parsed) {
           const newVal = document.getElementById('pp-table-edit').value.replace(/\n/g, '\\n').trim();
           pushHistory();
           let dsl = getDsl();
-          if (newVal) { dsl = updateProp('state', stateId, field, newVal, dsl); }
-          else { dsl = dsl.replace(new RegExp(`(^\\s*state\\s+${stateId}\\s+.*)\\b${field}=\\S+`, 'm'), '$1'); }
+          if (newVal) { dsl = updateProp('state', stBareId, field, newVal, dsl, stLine); }
+          else if (stLine != null) {
+            const dslLines = dsl.split('\n');
+            const li = stLine - 1;
+            if (li >= 0 && li < dslLines.length) dslLines[li] = dslLines[li].replace(new RegExp(`\\b${field}=\\S+`), '');
+            dsl = dslLines.join('\n');
+          } else { dsl = dsl.replace(new RegExp(`(^\\s*state\\s+${stBareId}\\s+.*)\\b${field}=\\S+`, 'm'), '$1'); }
           setDsl(dsl);
           refresh();
         });
@@ -4089,6 +4096,8 @@ function setupInteractions() {
       const rtype = handle.dataset.rtype;
       const el = parsed.stateMap[rid] || parsed.groupMap[rid] || parsed.noteMap[rid];
       if (!el) return;
+      const resizeBareId = el.id;
+      const resizeLine = el.line;
       pushHistory();
       const origX = el.x, origY = el.y, origW = el.w, origH = el.h;
       const sc = getSvgScale();
@@ -4112,8 +4121,8 @@ function setupInteractions() {
         if (newH === 1 && edge.includes('n')) newY = origY + origH - 1;
 
         let dsl = getDsl();
-        dsl = updatePos(rtype, rid, newX, newY, dsl);
-        dsl = updateSize(rtype, rid, newW, newH, dsl);
+        dsl = updatePos(rtype, resizeBareId, newX, newY, dsl, resizeLine);
+        dsl = updateSize(rtype, resizeBareId, newW, newH, dsl, resizeLine);
         setDsl(dsl);
         parsed = parseDSL(getDsl());
         document.getElementById('svg-wrap').innerHTML = renderSVG(parsed);
@@ -4329,14 +4338,24 @@ function connectSelected() {
 // ═══════════════════════════════════════════════
 // Delete Selected
 // ═══════════════════════════════════════════════
-function removeDSLElement(id, dsl) {
+function removeDSLElement(id, dsl, lineNum) {
+  const bareId = id.includes('.') ? id.split('.').pop() : id;
   const lines = dsl.split('\n');
   const result = [];
   let skipNesting = 0;
-  for (const line of lines) {
+  let foundDefLine = false;
+  for (let li = 0; li < lines.length; li++) {
+    const line = lines[li];
     const trimmed = line.trim();
     // Check if this line defines the element
-    if (trimmed.match(new RegExp(`^(state|group|note|initial|final|choice|history|deephistory|fork|join)\\s+${id}\\b`))) {
+    const isDefLine = trimmed.match(new RegExp(`^(state|group|note|initial|final|choice|history|deephistory|fork|join)\\s+${bareId}\\b`));
+    if (isDefLine && !foundDefLine) {
+      // If lineNum specified, only match that specific line
+      if (lineNum != null && (li + 1) !== lineNum) {
+        result.push(line);
+        continue;
+      }
+      foundDefLine = true;
       if (trimmed.endsWith('{')) skipNesting = 1;
       continue; // skip this line
     }
@@ -4348,12 +4367,9 @@ function removeDSLElement(id, dsl) {
       if (trimmed.endsWith('{')) skipNesting++;
       continue;
     }
-    // Remove transitions referencing this ID (as source or target)
-    if (trimmed.match(new RegExp(`^${id}\\s*->`)) || trimmed.match(new RegExp(`->\\s*${id}(\\s|$)`))) {
-      continue;
-    }
-    // Also handle dot-path references like parent.id or id.child
-    if (trimmed.match(new RegExp(`^\\S*\\.${id}\\s*->|^${id}\\.\\S+\\s*->|->\\s*\\S*\\.${id}(\\s|$)|->\\s*${id}\\.\\S+`))) {
+    // Remove transitions referencing this ID (as source or target, using path or bare ID)
+    const transId = id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    if (trimmed.match(new RegExp(`^${transId}\\s*->`)) || trimmed.match(new RegExp(`->\\s*${transId}(\\s|$)`))) {
       continue;
     }
     result.push(line);
@@ -4379,7 +4395,8 @@ function deleteSelected() {
   pushHistory();
   let dsl = getDsl();
   for (const si of sel) {
-    dsl = removeDSLElement(si.id, dsl);
+    const el = parsed.stateMap[si.id] || parsed.pseudoMap[si.id] || parsed.groupMap[si.id] || parsed.noteMap[si.id];
+    dsl = removeDSLElement(si.id, dsl, el ? el.line : null);
   }
   sel = [];
   setDsl(dsl);
@@ -4616,15 +4633,19 @@ function copySelection() {
   const dsl = getDsl();
   const lines = dsl.split('\n');
   for (const si of sel) {
-    const id = si.id;
+    const el = parsed.stateMap[si.id] || parsed.pseudoMap[si.id] || parsed.groupMap[si.id] || parsed.noteMap[si.id];
+    const startLine = el ? el.line : null;
+    const bareId = el ? el.id : si.id;
     // Find the DSL lines that define this element
     let collecting = false;
     let nestDepth = 0;
     const collected = [];
-    for (const line of lines) {
+    for (let li = 0; li < lines.length; li++) {
+      const line = lines[li];
       const trimmed = line.trim();
       if (!collecting) {
-        if (trimmed.match(new RegExp(`^(state|group|note|initial|final|choice|history|deephistory|fork|join)\\s+${id}\\b`))) {
+        const isDefLine = trimmed.match(new RegExp(`^(state|group|note|initial|final|choice|history|deephistory|fork|join)\\s+${bareId}\\b`));
+        if (isDefLine && (startLine == null || (li + 1) === startLine)) {
           collecting = true;
           collected.push(line);
           if (trimmed.endsWith('{')) nestDepth = 1;
@@ -4651,7 +4672,8 @@ function cutSelection() {
   pushHistory();
   let dsl = getDsl();
   sel.forEach(si => {
-    dsl = removeDSLElement(si.id, dsl);
+    const el = parsed.stateMap[si.id] || parsed.pseudoMap[si.id] || parsed.groupMap[si.id] || parsed.noteMap[si.id];
+    dsl = removeDSLElement(si.id, dsl, el ? el.line : null);
   });
   sel = [];
   setDsl(dsl);

--- a/stablestate.html
+++ b/stablestate.html
@@ -848,7 +848,7 @@ function resolveStateRef(dotPath, parsed) {
     let match = true, cur = c;
     for (let i = parts.length - 2; i >= 0; i--) {
       if (!cur.parent || cur.parent !== parts[i]) { match = false; break; }
-      cur = parsed.stateMap[cur.parent];
+      cur = parsed.stateMap[cur.parentPath || cur.parent];
     }
     if (match) return c;
   }
@@ -959,7 +959,7 @@ function validate(result) {
   // ─── Nesting bounds: child state coords+size exceeding parent bounds → warning ───
   for (const s of result.states) {
     if (!s.parent) continue;
-    const parent = result.stateMap[s.parent];
+    const parent = result.stateMap[s.parentPath || s.parent];
     if (!parent) continue;
     // Child coords are relative to parent
     if (s.x + s.w > parent.w || s.y + s.h > parent.h || s.x < 0 || s.y < 0) {
@@ -1492,10 +1492,10 @@ function esc(s) {
 // ═══════════════════════════════════════════════
 function getAbsolutePos(element, parsed) {
   let ox = 0, oy = 0;
-  let pid = element.parent;
+  let pid = element.parentPath || element.parent;
   while (pid) {
     const p = parsed.stateMap[pid];
-    if (p) { ox += p.x; oy += p.y; pid = p.parent; }
+    if (p) { ox += p.x; oy += p.y; pid = p.parentPath || p.parent; }
     else break;
   }
   return { x: (element.x + ox) * parsed.canvas.grid, y: (element.y + oy) * parsed.canvas.grid };
@@ -2368,7 +2368,7 @@ function renderTable(parsed) {
     if (lc.isSelf) chain.push(lc.state); // self column includes itself as ancestor
     let cur = lc.state;
     while (cur.parent) {
-      const p = parsed.stateMap[cur.parent];
+      const p = parsed.stateMap[cur.parentPath || cur.parent];
       if (p) { chain.unshift(p); cur = p; }
       else break;
     }
@@ -3547,7 +3547,7 @@ function buildExcelData(p) {
   data.states.filter(s => s.parent === null).forEach(function(s) { walk(s); });
 
   // Find max depth
-  function getDepth(st) { let d = 0, cur = st; while (cur.parent) { cur = data.stateMap[cur.parent]; d++; } return d; }
+  function getDepth(st) { let d = 0, cur = st; while (cur.parent) { cur = data.stateMap[cur.parentPath || cur.parent]; d++; } return d; }
   let maxDepth = 0;
   leafCols.forEach(function(lc) { const d = getDepth(lc); if (d > maxDepth) maxDepth = d; });
   const headerRows = maxDepth + 1;
@@ -3571,7 +3571,7 @@ function buildExcelData(p) {
       const lc = leafCols[ci];
       const chain = [];
       let cur = lc;
-      while (cur.parent) { const pp = data.stateMap[cur.parent]; if (pp) { chain.unshift(pp); cur = pp; } else break; }
+      while (cur.parent) { const pp = data.stateMap[cur.parentPath || cur.parent]; if (pp) { chain.unshift(pp); cur = pp; } else break; }
       // chain = ancestors, lc = leaf. chain.length = depth
       const depth = chain.length;
       const leafRow = depth; // row where leaf label appears
@@ -3583,7 +3583,7 @@ function buildExcelData(p) {
           const prevLc = leafCols[ci - 1];
           const prevChain = [];
           let pcur = prevLc;
-          while (pcur.parent) { const pp = data.stateMap[pcur.parent]; if (pp) { prevChain.unshift(pp); pcur = pp; } else break; }
+          while (pcur.parent) { const pp = data.stateMap[pcur.parentPath || pcur.parent]; if (pp) { prevChain.unshift(pp); pcur = pp; } else break; }
           if (r < prevChain.length && prevChain[r].id === anc.id) {
             row.push(''); // same group, empty
             sty.push({ bg: CLR.headerBg });
@@ -4183,7 +4183,7 @@ function setupInteractions() {
                          item.type === 'group' ? 'group' :
                          item.type === 'note' ? 'note' : item.type;
           if (item.parent) {
-            const parentSt = parsed.stateMap[item.parent];
+            const parentSt = parsed.stateMap[item.parentPath || item.parent];
             if (parentSt) {
               const newX = Math.max(0, Math.min(parentSt.w - (item.w || 1), item.origX + dxGrid));
               const newY = Math.max(0, Math.min(parentSt.h - (item.h || 1), item.origY + dyGrid));

--- a/stablestate.html
+++ b/stablestate.html
@@ -2377,16 +2377,16 @@ function renderTable(parsed) {
     if (fromEl && fromEl.type === 'initial') {
       // Resolve the target
       const tgt = resolveStateRef(t.to, parsed);
-      if (tgt) initialTargets.add(tgt.id);
+      if (tgt) initialTargets.add(tgt.path || tgt.id);
     }
   }
 
   // Depth-first walk: composite states also get a self-column at child depth
   function walkState(st, depth) {
     if (st.children.length === 0) {
-      leafColumns.push({ id: st.id, state: st, depth: depth, isInitial: initialTargets.has(st.id) });
+      leafColumns.push({ id: st.path || st.id, state: st, depth: depth, isInitial: initialTargets.has(st.path || st.id) });
     } else {
-      leafColumns.push({ id: st.id, state: st, depth: depth + 1, isInitial: false, isSelf: true });
+      leafColumns.push({ id: st.path || st.id, state: st, depth: depth + 1, isInitial: false, isSelf: true });
       for (const childId of st.children) {
         const child = parsed.stateMap[childId];
         if (child) walkState(child, depth + 1);
@@ -4393,10 +4393,14 @@ function removeDSLElement(id, dsl, lineNum) {
 function deleteSelected() {
   if (!sel.length) return;
   pushHistory();
-  let dsl = getDsl();
-  for (const si of sel) {
+  // Sort by line number descending to avoid line shift issues
+  const items = sel.map(si => {
     const el = parsed.stateMap[si.id] || parsed.pseudoMap[si.id] || parsed.groupMap[si.id] || parsed.noteMap[si.id];
-    dsl = removeDSLElement(si.id, dsl, el ? el.line : null);
+    return { id: si.id, line: el ? el.line : null };
+  }).sort((a, b) => (b.line || 0) - (a.line || 0));
+  let dsl = getDsl();
+  for (const item of items) {
+    dsl = removeDSLElement(item.id, dsl, item.line);
   }
   sel = [];
   setDsl(dsl);
@@ -4671,10 +4675,13 @@ function cutSelection() {
   copySelection();
   pushHistory();
   let dsl = getDsl();
-  sel.forEach(si => {
+  const cutItems = sel.map(si => {
     const el = parsed.stateMap[si.id] || parsed.pseudoMap[si.id] || parsed.groupMap[si.id] || parsed.noteMap[si.id];
-    dsl = removeDSLElement(si.id, dsl, el ? el.line : null);
-  });
+    return { id: si.id, line: el ? el.line : null };
+  }).sort((a, b) => (b.line || 0) - (a.line || 0));
+  for (const item of cutItems) {
+    dsl = removeDSLElement(item.id, dsl, item.line);
+  }
   sel = [];
   setDsl(dsl);
   refresh();

--- a/stablestate.html
+++ b/stablestate.html
@@ -4340,30 +4340,24 @@ function connectSelected() {
 // ═══════════════════════════════════════════════
 function removeDSLElement(id, dsl, lineNum) {
   const bareId = id.includes('.') ? id.split('.').pop() : id;
-  console.log('[removeDSLElement] id=', id, 'bareId=', bareId, 'lineNum=', lineNum);
+  const escBareId = bareId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const lines = dsl.split('\n');
   const result = [];
   let skipNesting = 0;
   let foundDefLine = false;
+  const defRe = new RegExp(`^(state|group|note|initial|final|choice|history|deephistory|fork|join)\\s+${escBareId}\\b`);
   for (let li = 0; li < lines.length; li++) {
     const line = lines[li];
     const trimmed = line.trim();
-    // Check if this line defines the element
-    const isDefLine = trimmed.match(new RegExp(`^(state|group|note|initial|final|choice|history|deephistory|fork|join)\\s+${bareId}\\b`));
-    if (isDefLine) {
-      console.log('[removeDSLElement] found def at line', li + 1, ':', trimmed);
-    }
+    const isDefLine = defRe.test(trimmed);
     if (isDefLine && !foundDefLine) {
-      // If lineNum specified, only match that specific line
       if (lineNum != null && (li + 1) !== lineNum) {
-        console.log('[removeDSLElement] skipping line', li + 1, '(not target)');
         result.push(line);
         continue;
       }
-      console.log('[removeDSLElement] DELETING line', li + 1);
       foundDefLine = true;
       if (trimmed.endsWith('{')) skipNesting = 1;
-      continue; // skip this line
+      continue;
     }
     if (skipNesting > 0) {
       if (trimmed === '}' || trimmed.startsWith('}')) {
@@ -4397,8 +4391,7 @@ function removeDSLElement(id, dsl, lineNum) {
 }
 
 function deleteSelected() {
-  console.log('[deleteSelected] called, sel=', JSON.stringify(sel));
-  if (!sel.length) { console.log('[deleteSelected] sel empty, returning'); return; }
+  if (!sel.length) return;
   pushHistory();
   // Sort by line number descending to avoid line shift issues
   const items = sel.map(si => {
@@ -5089,7 +5082,7 @@ document.addEventListener('keydown', function(e) {
   // Ctrl+V: Paste
   if ((e.ctrlKey || e.metaKey) && e.key === 'v') { e.preventDefault(); pasteSelection(); return; }
   // Delete / Backspace
-  if (e.key === 'Delete' || e.key === 'Backspace') { console.log('[keydown] Delete pressed'); e.preventDefault(); deleteSelected(); return; }
+  if (e.key === 'Delete' || e.key === 'Backspace') { e.preventDefault(); deleteSelected(); return; }
   // Ctrl+A: Select all
   if ((e.ctrlKey || e.metaKey) && e.key === 'a') {
     e.preventDefault();

--- a/stablestate.html
+++ b/stablestate.html
@@ -1349,19 +1349,29 @@ function applyChoiceBranches(stateId, evName, branches, defaultTarget, parsed, d
   // Recursively apply branches to a choice node
   function applyBranchesToChoice(cId, branchList, existingOutgoing) {
     const newBranches = [];
+    const nestedRecursions = []; // [{subId, children, subOutgoing}]
     let hasElse = false;
-    for (const b of branchList) {
+    for (let bi = 0; bi < branchList.length; bi++) {
+      const b = branchList[bi];
       if (!b.guard) hasElse = true;
       if (b.children && b.children.length > 0) {
-        // Nested: create sub-choice
-        const subId = nextAutoId();
-        const srcState = parsed.stateMap[stateId];
-        const cx = srcState ? srcState.x + srcState.w + 4 : 12;
-        const cy = srcState ? srcState.y + Math.floor(srcState.h / 2) + 2 : 12;
-        dsl = dsl.trimEnd() + '\nchoice ' + subId + ' at ' + cx + ',' + cy + '\n';
+        // Nested: reuse existing sub-choice if possible
+        let subId = null;
+        const existingAtIdx = existingOutgoing && existingOutgoing[bi];
+        if (existingAtIdx && parsed.pseudoMap[existingAtIdx.to] && parsed.pseudoMap[existingAtIdx.to].type === 'choice') {
+          subId = existingAtIdx.to;
+        } else {
+          // Create new sub-choice
+          subId = nextAutoId();
+          const srcState = parsed.stateMap[stateId];
+          const cx = srcState ? srcState.x + srcState.w + 4 : 12;
+          const cy = srcState ? srcState.y + Math.floor(srcState.h / 2) + 2 : 12;
+          dsl = dsl.trimEnd() + '\nchoice ' + subId + ' at ' + cx + ',' + cy + '\n';
+        }
         newBranches.push({ target: subId, guard: b.guard, action: null });
-        // Recurse into sub-choice
-        applyBranchesToChoice(subId, b.children, []);
+        // Queue recursion with existing sub-choice's outgoing transitions
+        const subOutgoing = parsed.transitions.filter(t => t.from === subId);
+        nestedRecursions.push({ subId, children: b.children, subOutgoing });
       } else {
         const tgt = b.target || defaultTarget;
         if (tgt) {
@@ -1395,6 +1405,10 @@ function applyChoiceBranches(stateId, evName, branches, defaultTarget, parsed, d
       for (const nb of newBranches) {
         dsl = addTransition(cId, nb.target, null, nb.guard, nb.action, null, dsl);
       }
+    }
+    // Recursively process nested sub-choices
+    for (const nr of nestedRecursions) {
+      applyBranchesToChoice(nr.subId, nr.children, nr.subOutgoing);
     }
   }
 

--- a/stablestate.html
+++ b/stablestate.html
@@ -1283,7 +1283,7 @@ function applyChoiceBranches(stateId, evName, branches, defaultTarget, parsed, d
   let choiceId = null;
   for (const t of parsed.transitions) {
     const fromEl = resolveStateRef(t.from, parsed);
-    if (fromEl && fromEl.id === stateId && (t.event || null) === ev) {
+    if (fromEl && (fromEl.path === stateId || fromEl.id === stateId) && (t.event || null) === ev) {
       if (parsed.pseudoMap[t.to] && parsed.pseudoMap[t.to].type === 'choice') {
         choiceId = t.to;
         break;
@@ -1324,7 +1324,7 @@ function applyChoiceBranches(stateId, evName, branches, defaultTarget, parsed, d
     // Point source transition to the choice
     const existingTrans = parsed.transitions.find(t => {
       const fromEl = resolveStateRef(t.from, parsed);
-      return fromEl && fromEl.id === stateId && (t.event || null) === ev;
+      return fromEl && (fromEl.path === stateId || fromEl.id === stateId) && (t.event || null) === ev;
     });
     if (existingTrans) {
       dsl = replaceTransition(existingTrans.from, existingTrans.to, existingTrans.event, existingTrans.guard,
@@ -2543,7 +2543,7 @@ function renderTable(parsed) {
     for (const lc of leafColumns) {
       const matching = transitions.filter(function(t) {
         const fromEl = resolveStateRef(t.from, parsed);
-        return fromEl && fromEl.id === lc.id;
+        return fromEl && (fromEl.path === lc.id || fromEl.id === lc.id);
       });
       const val = matching.length > 0 && matching[0].guard ? matching[0].guard : '-';
       bodyHtml += `<td class="table-editable" data-field="guard" data-state="${lc.id}" data-event="${esc(evName)}" style="cursor:pointer;color:#C3E88D">${esc(val).replace(/\\n/g, '<br>')}</td>`;
@@ -2555,7 +2555,7 @@ function renderTable(parsed) {
     for (const lc of leafColumns) {
       const matching = transitions.filter(function(t) {
         const fromEl = resolveStateRef(t.from, parsed);
-        return fromEl && fromEl.id === lc.id;
+        return fromEl && (fromEl.path === lc.id || fromEl.id === lc.id);
       });
       let val = matching.length > 0 && matching[0].action ? matching[0].action : '-';
       if (matching.length > 0) {
@@ -2571,7 +2571,7 @@ function renderTable(parsed) {
     for (const lc of leafColumns) {
       const matching = transitions.filter(function(t) {
         const fromEl = resolveStateRef(t.from, parsed);
-        return fromEl && fromEl.id === lc.id;
+        return fromEl && (fromEl.path === lc.id || fromEl.id === lc.id);
       });
       let val = '-';
       if (matching.length > 0) {
@@ -2668,7 +2668,7 @@ function renderTable(parsed) {
       // Transition fields — unified target/guard/action form
       const mt = parsed.transitions.filter(function(t) {
         const fromEl = resolveStateRef(t.from, parsed);
-        return fromEl && fromEl.id === stateId && (t.event || '(none)') === evName;
+        return fromEl && (fromEl.path === stateId || fromEl.id === stateId) && (t.event || '(none)') === evName;
       });
       const existing = mt.length > 0 ? mt[0] : null;
       const curGuard = existing ? existing.guard || '' : '';
@@ -3709,7 +3709,7 @@ function buildExcelData(p) {
       for (const lc of leafCols) {
         const matching = transitions.filter(function(t) {
           const fromEl = resolveStateRef(t.from, data);
-          return fromEl && fromEl.id === lc.id;
+          return fromEl && (fromEl.path === lc.id || fromEl.id === lc.id);
         });
         let val = '-';
         if (matching.length > 0) {

--- a/stablestate.html
+++ b/stablestate.html
@@ -564,20 +564,30 @@ function parseDSL(text) {
     const pseudoMatch = trimmed.match(/^(initial|final|choice|history|deephistory|fork|join)\s+(\S+)\s+at\s+(-?[\d.]+)\s*,\s*(-?[\d.]+)(?:\s+size\s+(-?[\d.]+)\s*x\s*(-?[\d.]+))?/);
     if (pseudoMatch) {
       const id = pseudoMatch[2];
-      // Duplicate ID check across all maps
-      if (checkDuplicate(id, lineNum, result)) continue;
+      const psParentEntry = nestingStack.length > 0 ? nestingStack.findLast(e => e.type === 'state') : null;
+      const psParentId = psParentEntry ? psParentEntry.id : null;
+      const psParentPath = psParentEntry ? psParentEntry.path : null;
+      const psPath = psParentPath ? psParentPath + '.' + id : id;
+      // Duplicate ID check by path
+      if (result.pseudoMap[psPath]) {
+        result.errors.push({ line: lineNum, msg: 'Duplicate pseudo-state path: ' + psPath });
+        continue;
+      }
       const ps = {
         type: pseudoMatch[1],
         id: id,
+        path: psPath,
         x: parseFloat(pseudoMatch[3]),
         y: parseFloat(pseudoMatch[4]),
         w: pseudoMatch[5] ? parseFloat(pseudoMatch[5]) : null,
         h: pseudoMatch[6] ? parseFloat(pseudoMatch[6]) : null,
-        parent: nestingStack.length > 0 ? nestingStack.findLast(e => e.type === 'state')?.id || null : null,
+        parent: psParentId,
+        parentPath: psParentPath,
         line: lineNum
       };
       result.pseudoStates.push(ps);
-      result.pseudoMap[id] = ps;
+      result.pseudoMap[psPath] = ps;
+      if (!result.pseudoMap[id]) result.pseudoMap[id] = ps;
       continue;
     }
 
@@ -4751,7 +4761,9 @@ function fixIds() {
   for (const el of allElements) {
     const newId = labelToId(el.label);
     if (!newId || newId === el.id) continue;
-    if (parsed.stateMap[newId] || parsed.pseudoMap[newId] || parsed.groupMap[newId] || parsed.noteMap[newId]) continue;
+    // Check collision using path (allows same bare ID under different parents)
+    const newPath = el.parentPath ? el.parentPath + '.' + newId : newId;
+    if (parsed.stateMap[newPath] || parsed.pseudoMap[newId] || parsed.groupMap[newId] || parsed.noteMap[newId]) continue;
     const idRe = new RegExp('\\b' + el.id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\b', 'g');
     dsl = dsl.replace(idRe, newId);
   }

--- a/stablestate.html
+++ b/stablestate.html
@@ -2744,7 +2744,7 @@ function renderTable(parsed) {
       function buildCandidates(type, prefix) {
         if (type === 'state') {
           if (!parsed) return [];
-          return parsed.states.map(s => stateDotPath(s.id));
+          return parsed.states.map(s => s.path || s.id);
         }
         if (type === 'keyword') {
           return AC_KEYWORDS;

--- a/stablestate.html
+++ b/stablestate.html
@@ -4397,7 +4397,8 @@ function removeDSLElement(id, dsl, lineNum) {
 }
 
 function deleteSelected() {
-  if (!sel.length) return;
+  console.log('[deleteSelected] called, sel=', JSON.stringify(sel));
+  if (!sel.length) { console.log('[deleteSelected] sel empty, returning'); return; }
   pushHistory();
   // Sort by line number descending to avoid line shift issues
   const items = sel.map(si => {
@@ -5088,7 +5089,7 @@ document.addEventListener('keydown', function(e) {
   // Ctrl+V: Paste
   if ((e.ctrlKey || e.metaKey) && e.key === 'v') { e.preventDefault(); pasteSelection(); return; }
   // Delete / Backspace
-  if (e.key === 'Delete' || e.key === 'Backspace') { e.preventDefault(); deleteSelected(); return; }
+  if (e.key === 'Delete' || e.key === 'Backspace') { console.log('[keydown] Delete pressed'); e.preventDefault(); deleteSelected(); return; }
   // Ctrl+A: Select all
   if ((e.ctrlKey || e.metaKey) && e.key === 'a') {
     e.preventDefault();

--- a/stablestate.html
+++ b/stablestate.html
@@ -983,7 +983,17 @@ function validate(result) {
 // ═══════════════════════════════════════════════
 
 // Update position (at X,Y) for a given element type and id
-function updatePos(type, id, nx, ny, dsl) {
+function updatePos(type, id, nx, ny, dsl, lineNum) {
+  if (lineNum != null) {
+    // Line-number based update (for duplicate IDs)
+    const lines = dsl.split('\n');
+    const idx = lineNum - 1;
+    if (idx >= 0 && idx < lines.length) {
+      const re = new RegExp(`^(\\s*${type}\\s+${id}\\s+(?:"[^"]*"\\s+)?at\\s+)[\\d.]+,[\\d.]+(.*$)`);
+      lines[idx] = lines[idx].replace(re, `$1${nx},${ny}$2`);
+    }
+    return lines.join('\n');
+  }
   const re = new RegExp(`^(\\s*${type}\\s+${id}\\s+(?:"[^"]*"\\s+)?at\\s+)[\\d.]+,[\\d.]+(.*$)`, 'm');
   return dsl.replace(re, `$1${nx},${ny}$2`);
 }
@@ -4152,7 +4162,7 @@ function setupInteractions() {
         else if (parsed.groupMap[si.id]) elType = 'group';
         else if (parsed.noteMap[si.id]) elType = 'note';
         else elType = 'state';
-        dragItems.push({ id: si.id, bareId: el.id, type: elType, origX: el.x, origY: el.y, parent: el.parent || null, parentPath: el.parentPath || null, w: el.w, h: el.h });
+        dragItems.push({ id: si.id, bareId: el.id, type: elType, origX: el.x, origY: el.y, parent: el.parent || null, parentPath: el.parentPath || null, w: el.w, h: el.h, line: el.line });
       }
       // Groups drag contained states
       for (const si of sel) {
@@ -4162,7 +4172,7 @@ function setupInteractions() {
           const cx = st.x + (st.w || 0) / 2, cy = st.y + (st.h || 0) / 2;
           if (cx >= grp.x && cx <= grp.x + grp.w && cy >= grp.y && cy <= grp.y + grp.h) {
             if (!dragItems.some(it => it.id === (st.path || st.id))) {
-              dragItems.push({ id: st.path || st.id, bareId: st.id, type: 'state', origX: st.x, origY: st.y, parent: st.parent, parentPath: st.parentPath || null, w: st.w, h: st.h });
+              dragItems.push({ id: st.path || st.id, bareId: st.id, type: 'state', origX: st.x, origY: st.y, parent: st.parent, parentPath: st.parentPath || null, w: st.w, h: st.h, line: st.line });
             }
           }
         }
@@ -4198,14 +4208,14 @@ function setupInteractions() {
             if (parentSt) {
               const newX = Math.max(0, Math.min(parentSt.w - (item.w || 1), item.origX + dxGrid));
               const newY = Math.max(0, Math.min(parentSt.h - (item.h || 1), item.origY + dyGrid));
-              dsl = updatePos(elType, dslId, newX, newY, dsl);
+              dsl = updatePos(elType, dslId, newX, newY, dsl, item.line);
             } else {
-              dsl = updatePos(elType, dslId, item.origX + dxGrid, item.origY + dyGrid, dsl);
+              dsl = updatePos(elType, dslId, item.origX + dxGrid, item.origY + dyGrid, dsl, item.line);
             }
           } else {
             const newX = Math.max(0, item.origX + dxGrid);
             const newY = Math.max(0, item.origY + dyGrid);
-            dsl = updatePos(elType, dslId, newX, newY, dsl);
+            dsl = updatePos(elType, dslId, newX, newY, dsl, item.line);
           }
         }
         setDsl(dsl);

--- a/stablestate.html
+++ b/stablestate.html
@@ -302,7 +302,7 @@ let currentTool = 'select';
 let connectFrom = null; // first element ID in connect mode
 let showActions = false;
 let zoomLevel = 100;
-let sel = []; // [{type, id}, ...] — StableBlock compatible
+let sel = []; // [{type, id}, ...] — id is path for states/pseudo, bare for groups/notes
 function isSel(id) { return sel.some(s => s.id === id); }
 function isSelected(id) { return isSel(id); } // renderSVG compat wrapper
 
@@ -1562,7 +1562,7 @@ function renderSVG(parsed) {
     const border = st.borderColor || '#6366F1';
     const textClr = st.textColor || '#e0e0e0';
     const round = st.round != null ? st.round : 10;
-    const elSel = isSelected(st.id);
+    const elSel = isSelected(st.path || st.id);
     const strokeClr = elSel ? 'white' : border;
     const strokeW = elSel ? 2.5 : 1.5;
     const dashAttr = st.style === 'dashed' ? ' stroke-dasharray="6 3"' : '';
@@ -1572,7 +1572,7 @@ function renderSVG(parsed) {
     const dimSt = dimStVal ? ` opacity="${dimStVal}"` : '';
     const stShadow = elSel ? 'filter="drop-shadow(0 4px 12px rgba(99,102,241,0.5))"' : shadow;
 
-    svg += `<g data-type="state" data-id="${st.id}" style="cursor:${annotationMode?'default':'grab'}"${dimSt}>`;
+    svg += `<g data-type="state" data-id="${st.path || st.id}" style="cursor:${annotationMode?'default':'grab'}"${dimSt}>`;
     svg += `<rect x="${pos.x}" y="${pos.y}" width="${pw}" height="${ph}" rx="${round}" ry="${round}" fill="${esc(fill)}" stroke="${esc(strokeClr)}" stroke-width="${strokeW}"${dashAttr} ${stShadow}/>`;
     svg += `<text x="${pos.x + 10}" y="${pos.y + 18}" font-family="${sans}" font-size="12" font-weight="600" fill="${esc(textClr)}" style="pointer-events:none">${esc(st.label)}</text>`;
 
@@ -1617,7 +1617,7 @@ function renderSVG(parsed) {
     const border = st.borderColor || '#818CF8';
     const textClr = st.textColor || '#e0e0e0';
     const round = st.round != null ? st.round : 10;
-    const elSel = isSelected(st.id);
+    const elSel = isSelected(st.path || st.id);
     const strokeClr = elSel ? 'white' : border;
     const strokeW = elSel ? 2.5 : 1.5;
     const dashAttr = st.style === 'dashed' ? ' stroke-dasharray="6 3"' : '';
@@ -1628,7 +1628,7 @@ function renderSVG(parsed) {
     const dimSt = dimStVal ? ` opacity="${dimStVal}"` : '';
     const stShadow = elSel ? 'filter="drop-shadow(0 4px 12px rgba(99,102,241,0.5))"' : shadow;
 
-    svg += `<g data-type="state" data-id="${st.id}" style="cursor:${annotationMode?'default':'grab'}"${dimSt}>`;
+    svg += `<g data-type="state" data-id="${st.path || st.id}" style="cursor:${annotationMode?'default':'grab'}"${dimSt}>`;
     svg += `<rect x="${pos.x}" y="${pos.y}" width="${pw}" height="${ph}" rx="${round}" ry="${round}" fill="${esc(fill)}" stroke="${esc(strokeClr)}" stroke-width="${strokeW}"${dashAttr} ${stShadow}/>`;
 
     if (hasActions) {
@@ -1664,9 +1664,9 @@ function renderSVG(parsed) {
     const dimPsHl = hlIds && !hlIds.has(ps.id) ? 0.15 : null;
     const dimPsVal = dimPsSearch || dimPsHl;
     const dimPs = dimPsVal ? ` opacity="${dimPsVal}"` : '';
-    const psSel = isSelected(ps.id);
+    const psSel = isSelected(ps.path || ps.id);
     const psShadow = psSel ? 'filter="drop-shadow(0 4px 12px rgba(99,102,241,0.5))"' : shadow;
-    svg += `<g data-type="${ps.type}" data-id="${ps.id}" style="cursor:grab"${dimPs}>`;
+    svg += `<g data-type="${ps.type}" data-id="${ps.path || ps.id}" style="cursor:grab"${dimPs}>`;
 
     // Selection highlight ring
     if (psSel) {
@@ -5011,8 +5011,8 @@ document.addEventListener('keydown', function(e) {
       sel = parsed.notes.map(n => ({type: 'note', id: n.id}));
     } else {
       sel = [
-        ...parsed.states.map(s => ({type: 'state', id: s.id})),
-        ...parsed.pseudoStates.map(p => ({type: p.type, id: p.id})),
+        ...parsed.states.map(s => ({type: 'state', id: s.path || s.id})),
+        ...parsed.pseudoStates.map(p => ({type: p.type, id: p.path || p.id})),
         ...parsed.groups.map(g => ({type: 'group', id: g.id}))
       ];
     }
@@ -5098,7 +5098,7 @@ if (isVSCode) {
     if (msg.type === 'paste') { pasteSelection(); }
     if (msg.type === 'selectAll') {
       if (!parsed) return;
-      sel = [...parsed.states.map(s => ({type:'state',id:s.id})), ...parsed.pseudoStates.map(p => ({type:p.type,id:p.id})), ...parsed.groups.map(g => ({type:'group',id:g.id}))];
+      sel = [...parsed.states.map(s => ({type:'state',id:s.path||s.id})), ...parsed.pseudoStates.map(p => ({type:p.type,id:p.path||p.id})), ...parsed.groups.map(g => ({type:'group',id:g.id}))];
       refresh();
     }
   });

--- a/stablestate.html
+++ b/stablestate.html
@@ -4340,6 +4340,7 @@ function connectSelected() {
 // ═══════════════════════════════════════════════
 function removeDSLElement(id, dsl, lineNum) {
   const bareId = id.includes('.') ? id.split('.').pop() : id;
+  console.log('[removeDSLElement] id=', id, 'bareId=', bareId, 'lineNum=', lineNum);
   const lines = dsl.split('\n');
   const result = [];
   let skipNesting = 0;
@@ -4349,12 +4350,17 @@ function removeDSLElement(id, dsl, lineNum) {
     const trimmed = line.trim();
     // Check if this line defines the element
     const isDefLine = trimmed.match(new RegExp(`^(state|group|note|initial|final|choice|history|deephistory|fork|join)\\s+${bareId}\\b`));
+    if (isDefLine) {
+      console.log('[removeDSLElement] found def at line', li + 1, ':', trimmed);
+    }
     if (isDefLine && !foundDefLine) {
       // If lineNum specified, only match that specific line
       if (lineNum != null && (li + 1) !== lineNum) {
+        console.log('[removeDSLElement] skipping line', li + 1, '(not target)');
         result.push(line);
         continue;
       }
+      console.log('[removeDSLElement] DELETING line', li + 1);
       foundDefLine = true;
       if (trimmed.endsWith('{')) skipNesting = 1;
       continue; // skip this line

--- a/stablestate.html
+++ b/stablestate.html
@@ -4152,7 +4152,7 @@ function setupInteractions() {
         else if (parsed.groupMap[si.id]) elType = 'group';
         else if (parsed.noteMap[si.id]) elType = 'note';
         else elType = 'state';
-        dragItems.push({ id: si.id, type: elType, origX: el.x, origY: el.y, parent: el.parent || null, w: el.w, h: el.h });
+        dragItems.push({ id: si.id, bareId: el.id, type: elType, origX: el.x, origY: el.y, parent: el.parent || null, parentPath: el.parentPath || null, w: el.w, h: el.h });
       }
       // Groups drag contained states
       for (const si of sel) {
@@ -4161,8 +4161,8 @@ function setupInteractions() {
         for (const st of parsed.states) {
           const cx = st.x + (st.w || 0) / 2, cy = st.y + (st.h || 0) / 2;
           if (cx >= grp.x && cx <= grp.x + grp.w && cy >= grp.y && cy <= grp.y + grp.h) {
-            if (!dragItems.some(it => it.id === st.id)) {
-              dragItems.push({ id: st.id, type: 'state', origX: st.x, origY: st.y, parent: st.parent, w: st.w, h: st.h });
+            if (!dragItems.some(it => it.id === (st.path || st.id))) {
+              dragItems.push({ id: st.path || st.id, bareId: st.id, type: 'state', origX: st.x, origY: st.y, parent: st.parent, parentPath: st.parentPath || null, w: st.w, h: st.h });
             }
           }
         }
@@ -4192,19 +4192,20 @@ function setupInteractions() {
           const elType = item.type === 'state' ? 'state' :
                          item.type === 'group' ? 'group' :
                          item.type === 'note' ? 'note' : item.type;
+          const dslId = item.bareId || item.id;
           if (item.parent) {
             const parentSt = parsed.stateMap[item.parentPath || item.parent];
             if (parentSt) {
               const newX = Math.max(0, Math.min(parentSt.w - (item.w || 1), item.origX + dxGrid));
               const newY = Math.max(0, Math.min(parentSt.h - (item.h || 1), item.origY + dyGrid));
-              dsl = updatePos(elType, item.id, newX, newY, dsl);
+              dsl = updatePos(elType, dslId, newX, newY, dsl);
             } else {
-              dsl = updatePos(elType, item.id, item.origX + dxGrid, item.origY + dyGrid, dsl);
+              dsl = updatePos(elType, dslId, item.origX + dxGrid, item.origY + dyGrid, dsl);
             }
           } else {
             const newX = Math.max(0, item.origX + dxGrid);
             const newY = Math.max(0, item.origY + dyGrid);
-            dsl = updatePos(elType, item.id, newX, newY, dsl);
+            dsl = updatePos(elType, dslId, newX, newY, dsl);
           }
         }
         setDsl(dsl);

--- a/stablestate.html
+++ b/stablestate.html
@@ -808,9 +808,6 @@ function parseDSL(text) {
     result.errors.push({ line: lines.length, msg: 'Unclosed composite state: ' + nestingStack.join(', ') });
   }
 
-  console.log('[parseDSL] states:', result.states.map(s => ({id: s.id, path: s.path, parent: s.parent, line: s.line})));
-  console.log('[parseDSL] stateMap keys:', Object.keys(result.stateMap));
-  console.log('[parseDSL] errors:', result.errors);
   return result;
 }
 
@@ -4147,6 +4144,10 @@ function setupInteractions() {
       if (e.button !== 0) return;
       e.preventDefault();
       e.stopPropagation();
+      // Remove focus from DSL editor so Delete key works for app
+      if (document.activeElement && document.activeElement.tagName === 'TEXTAREA') {
+        document.activeElement.blur();
+      }
       const id = gEl.dataset.id;
       const type = gEl.dataset.type;
 
@@ -4394,8 +4395,7 @@ function removeDSLElement(id, dsl, lineNum) {
 }
 
 function deleteSelected() {
-  console.log('[deleteSelected] sel=', JSON.stringify(sel));
-  if (!sel.length) { console.log('[deleteSelected] sel empty'); return; }
+  if (!sel.length) return;
   pushHistory();
   // Sort by line number descending to avoid line shift issues
   const items = sel.map(si => {


### PR DESCRIPTION
## Summary

- stateMapのキーをドットパス（例: \`active.accel\`）に変更し、親状態が異なれば子状態のbare IDが重複しても区別できるようにした
- 選択（sel配列）、描画（SVG data-id）、削除、コピー/カット、リサイズ、テーブル編集を全てpath/行番号ベースに対応
- DSL操作関数（updatePos/updateSize/updateLabel/updateProp/removeDSLElement）に行番号オプションを追加
- resolves KawanoMomo/StableState#19

## 主な変更

- **parseDSL**: 各stateに\`path\`/\`parentPath\`を追加、stateMapのキーをpathに
- **selection**: SVGのdata-idをpath化、sel配列にpathを格納
- **DSL操作**: bare IDでマッチすると重複時に誤った行を更新するため、行番号で特定可能に
- **削除**: 複数要素削除時の行ずれを避けるため行番号降順でソート
- **フォーカス**: 状態クリック時にDSLエディタのフォーカスを外してDeleteキーが動作
- **Ctrl+Z**: フォーム要素フォーカス時はネイティブundoに委譲

## Test plan

- [x] デフォルトサンプルで既存機能が動作
- [x] 親が異なる同一bare ID子状態（active.accel / mode2.accel）が両方表示される
- [x] 同一ID子状態を個別に選択・ハイライトできる
- [x] 同一ID子状態を個別にドラッグできる
- [x] 同一ID子状態を個別にリサイズできる
- [x] 同一ID子状態のプロパティ（ラベル/位置/サイズ/色）を個別に編集できる
- [x] 同一ID子状態を個別に削除できる
- [x] テーブルで同一ID子状態のentry/do/exitを個別に編集できる
- [x] DSLエディタでCtrl+Zがネイティブundoとして動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)