### PR TITLE
feat(cyclic): @cyclic transitions + do field editor extension

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,10 +1,11 @@
-// Playwright config for ux-brushup regression tests.
+// Playwright config for ux-brushup regression + cyclic-transitions tests.
 // Assumes a dev server is already running at http://localhost:8765 serving stablestate.html
 // (started by the Top-level conductor). Tests must not start or stop the server.
 const { defineConfig, devices } = require('@playwright/test');
 
 module.exports = defineConfig({
-  testDir: './tests/ux-brushup',
+  testDir: './tests',
+  testMatch: ['ux-brushup/**/*.spec.js', 'cyclic-transitions/**/*.spec.js'],
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: 0,

--- a/stablestate.html
+++ b/stablestate.html
@@ -840,6 +840,7 @@ function parseDSL(text) {
 
       // Parse optional : Event [Guard] / Action @kind width=N style=S color=C default=X
       let event = null, guard = null, action = null, kind = null, width = null, style = null, color = null, defaultTarget = null;
+      let isCyclic = false;
       if (rest.startsWith(':')) {
         const detail = rest.slice(1).trim();
         let remaining = detail;
@@ -854,11 +855,26 @@ function parseDSL(text) {
         }
         // Strip all key=value attrs from remaining
         remaining = remaining.replace(/\b(width|style|color|default)=\S+/g, '').trim();
-        // Parse @kind from the end
-        const kindMatch = remaining.match(/@(local|external|internal)\s*$/);
-        if (kindMatch) {
-          kind = kindMatch[1];
-          remaining = remaining.slice(0, remaining.lastIndexOf('@' + kind)).trim();
+        // Parse @cyclic and @kind suffixes (any order) from the end.
+        // @cyclic is orthogonal to @kind — both may appear, in either order.
+        // Loop strips whichever suffix currently terminates `remaining` until
+        // neither matches, which handles "@kind @cyclic" and "@cyclic @kind".
+        let suffixChanged = true;
+        while (suffixChanged) {
+          suffixChanged = false;
+          const cyclicMatch = remaining.match(/@cyclic\s*$/);
+          if (cyclicMatch) {
+            isCyclic = true;
+            remaining = remaining.slice(0, remaining.lastIndexOf('@cyclic')).trim();
+            suffixChanged = true;
+            continue;
+          }
+          const kindMatch = remaining.match(/@(local|external|internal)\s*$/);
+          if (kindMatch) {
+            kind = kindMatch[1];
+            remaining = remaining.slice(0, remaining.lastIndexOf('@' + kind)).trim();
+            suffixChanged = true;
+          }
         }
         // Parse / Action
         const slashIdx = remaining.indexOf('/');
@@ -883,6 +899,7 @@ function parseDSL(text) {
         guard: guard,
         action: action,
         kind: kind || result.config.transition,
+        cyclic: isCyclic,
         width: width,
         style: style,
         color: color,
@@ -1177,7 +1194,7 @@ function updateLabel(type, id, newLabel, dsl, lineNum) {
 }
 
 // Append a new transition line to the DSL
-function addTransition(from, to, event, guard, action, kind, dsl) {
+function addTransition(from, to, event, guard, action, kind, dsl, cyclic) {
   // Determine default transition kind from @config
   let defaultKind = 'local';
   const configMatch = dsl.match(/^@config\s+transition=(\S+)/m);
@@ -1188,13 +1205,15 @@ function addTransition(from, to, event, guard, action, kind, dsl) {
   const hasGuard = guard != null && guard !== '';
   const hasAction = action != null && action !== '';
   const hasKind = kind != null && kind !== '' && kind !== defaultKind;
+  const hasCyclic = cyclic === true;
 
-  if (hasEvent || hasGuard || hasAction || hasKind) {
+  if (hasEvent || hasGuard || hasAction || hasKind || hasCyclic) {
     line += ' :';
     if (hasEvent) line += ` ${event}`;
     if (hasGuard) line += ` [${guard}]`;
     if (hasAction) line += ` / ${action}`;
     if (hasKind) line += ` @${kind}`;
+    if (hasCyclic) line += ` @cyclic`;
   }
 
   return dsl + '\n' + line;
@@ -1213,8 +1232,16 @@ function removeTransition(from, to, event, guard, dsl) {
       let lineEvent = null, lineGuard = null;
       if (rest.startsWith(':')) {
         let detail = rest.slice(1).trim();
-        // Remove @kind
-        detail = detail.replace(/@(local|external|internal)\s*$/, '').trim();
+        // Remove @cyclic and @kind suffixes (either order)
+        let stripped = true;
+        while (stripped) {
+          stripped = false;
+          const before = detail;
+          detail = detail.replace(/@cyclic\s*$/, '').trim();
+          if (detail !== before) { stripped = true; continue; }
+          detail = detail.replace(/@(local|external|internal)\s*$/, '').trim();
+          if (detail !== before) stripped = true;
+        }
         // Remove action
         const slashIdx = detail.indexOf('/');
         if (slashIdx !== -1) detail = detail.slice(0, slashIdx).trim();
@@ -1237,7 +1264,7 @@ function removeTransition(from, to, event, guard, dsl) {
 }
 
 // Replace a matching transition line in-place (preserves DSL order)
-function replaceTransition(oldFrom, oldTo, oldEvent, oldGuard, newFrom, newTo, newEvent, newGuard, newAction, newKind, dsl) {
+function replaceTransition(oldFrom, oldTo, oldEvent, oldGuard, newFrom, newTo, newEvent, newGuard, newAction, newKind, dsl, newCyclic) {
   // Build the new transition line (same logic as addTransition)
   let defaultKind = 'local';
   const configMatch = dsl.match(/^@config\s+transition=(\S+)/m);
@@ -1253,12 +1280,14 @@ function replaceTransition(oldFrom, oldTo, oldEvent, oldGuard, newFrom, newTo, n
     const hasG = newGuard != null && newGuard !== '';
     const hasA = newAction != null && newAction !== '';
     const hasK = newKind != null && newKind !== '' && newKind !== defaultKind;
-    if (hasEv || hasG || hasA || hasK) {
+    const hasC = newCyclic === true;
+    if (hasEv || hasG || hasA || hasK || hasC) {
       line += ' :';
       if (hasEv) line += ` ${newEvent}`;
       if (hasG) line += ` [${newGuard}]`;
       if (hasA) line += ` / ${newAction}`;
       if (hasK) line += ` @${newKind}`;
+      if (hasC) line += ` @cyclic`;
     }
     return line;
   }
@@ -1275,7 +1304,17 @@ function replaceTransition(oldFrom, oldTo, oldEvent, oldGuard, newFrom, newTo, n
       let lineEvent = null, lineGuard = null;
       if (rest.startsWith(':')) {
         let detail = rest.slice(1).trim();
-        detail = detail.replace(/@(local|external|internal)\s*$/, '').trim();
+        // Strip @cyclic and @kind suffixes (either order) before extracting
+        // event/guard for the match comparison.
+        let stripped = true;
+        while (stripped) {
+          stripped = false;
+          const before = detail;
+          detail = detail.replace(/@cyclic\s*$/, '').trim();
+          if (detail !== before) { stripped = true; continue; }
+          detail = detail.replace(/@(local|external|internal)\s*$/, '').trim();
+          if (detail !== before) stripped = true;
+        }
         const slashIdx = detail.indexOf('/');
         if (slashIdx !== -1) detail = detail.slice(0, slashIdx).trim();
         const gm = detail.match(/\[([^\]]*)\]/);

--- a/stablestate.html
+++ b/stablestate.html
@@ -600,7 +600,7 @@ function parseDSL(text) {
         // Parse trailing props on the closing brace line: } entry=Foo exit=Bar
         const afterBrace = trimmed.slice(1).trim();
         if (afterBrace && result.stateMap[popped.path || popped.id]) {
-          parseProps(afterBrace, result.stateMap[popped.path || popped.id]);
+          parseProps(afterBrace, result.stateMap[popped.path || popped.id], lineNum, result.errors);
         }
       }
       continue;
@@ -742,7 +742,7 @@ function parseDSL(text) {
       };
 
       // Parse props
-      if (propsStr) parseProps(propsStr, st);
+      if (propsStr) parseProps(propsStr, st, lineNum, result.errors);
 
       result.states.push(st);
       result.stateMap[path] = st;
@@ -792,7 +792,7 @@ function parseDSL(text) {
         style: null,
         line: lineNum
       };
-      if (rest) parseProps(rest, g);
+      if (rest) parseProps(rest, g, lineNum, result.errors);
       result.groups.push(g);
       result.groupMap[id] = g;
       continue;
@@ -816,7 +816,7 @@ function parseDSL(text) {
         textColor: null,
         line: lineNum
       };
-      if (rest) parseProps(rest, n);
+      if (rest) parseProps(rest, n, lineNum, result.errors);
       result.notes.push(n);
       result.noteMap[id] = n;
       continue;
@@ -944,14 +944,22 @@ function parseDSL(text) {
   return result;
 }
 
-/** Parse key=value props and apply them to target object */
-function parseProps(propsStr, target) {
-  // Match key=value pairs where value can be #HEX, word, or quoted
-  const propRe = /(\w+)=(\S+)/g;
+/** Parse key=value props and apply them to target object.
+ *  Supports bare values (non-whitespace) and double-quoted values with \n / \" escapes.
+ *  When lineNum and errors are provided, pushes E4 errors for unclosed quotes. */
+function parseProps(propsStr, target, lineNum, errors) {
+  // Match either a quoted value "..." (with \" escapes) or a bare non-whitespace token.
+  // The quoted alternative uses [^"\\]|\\. so that escaped chars inside don't terminate it.
+  const propRe = /(\w+)=("(?:[^"\\]|\\.)*"|\S+)/g;
   let m;
   while ((m = propRe.exec(propsStr)) !== null) {
     const key = m[1];
-    const val = m[2];
+    let val = m[2];
+    // Unquote if fully quoted: strip outer quotes, unescape \" → " (keep \n as 2-char literal
+    // so UI layer can later convert to real newline for textarea display).
+    if (val.length >= 2 && val.charCodeAt(0) === 34 && val.charCodeAt(val.length - 1) === 34) {
+      val = val.slice(1, -1).replace(/\\"/g, '"');
+    }
     switch (key) {
       case 'entry': target.entry = val; break;
       case 'do': target.do = val; break;
@@ -961,6 +969,17 @@ function parseProps(propsStr, target) {
       case 'border': target.borderColor = val; break;
       case 'round': target.round = parseFloat(val); break;
       case 'style': target.style = val; break;
+    }
+  }
+  // E4: detect unclosed quoted values. When the input is e.g. `do="unclosed` with no closing
+  // quote, the quoted alternative of propRe fails but the bare \S+ alternative still matches
+  // (capturing `do=` + `"unclosed`), bypassing the unquote branch. We scan the raw input
+  // separately for this pattern so we can emit a precise diagnostic.
+  if (errors && lineNum != null) {
+    const unclosedRe = /(\w+)="[^"]*$/;
+    const um = propsStr.match(unclosedRe);
+    if (um) {
+      errors.push({ line: lineNum, msg: "L" + lineNum + ": unclosed quoted value for '" + um[1] + "'" });
     }
   }
 }

--- a/stablestate.html
+++ b/stablestate.html
@@ -2946,6 +2946,11 @@ function renderTable(parsed) {
       if (!isChoiceMode) html += `<button class="tb" id="pp-branch-btn" style="font-size:9px;padding:2px 6px;color:#C3E88D;border-color:#C3E88D">+ 分岐</button>`;
       html += `</div>`;
       html += `<textarea class="prop-input" id="pp-table-action" style="height:${isChoiceMode ? 100 : 60}px;resize:vertical;font-size:11px;line-height:1.4;text-align:left;font-family:Consolas,monospace" placeholder="アクション">${esc(curAction).replace(/\\n/g, '\n')}</textarea>`;
+      const curCyclic = existing && existing.cyclic === true;
+      html += `<label class="prop-row" style="display:flex;align-items:center;gap:6px;font-size:11px;color:#94a3b8;margin-top:6px;cursor:pointer">`;
+      html += `<input type="checkbox" id="pp-table-cyclic"${curCyclic ? ' checked' : ''} style="cursor:pointer">`;
+      html += `<span>${CYCLIC_GLYPH} @cyclic (周期評価)</span>`;
+      html += `</label>`;
       html += `<button class="tb tb-accent" id="pp-table-apply" style="width:100%;margin-top:6px">適用</button>`;
       if (existing) html += `<button class="tb" id="pp-table-delete" style="width:100%;margin-top:4px;border-color:#EF4444;color:#FCA5A5">遷移を削除</button>`;
       html += `</div>`;
@@ -3127,6 +3132,7 @@ function renderTable(parsed) {
         const target = document.getElementById('pp-table-target').value;
         const guard = document.getElementById('pp-table-guard').value.trim();
         const actionRaw = document.getElementById('pp-table-action').value;
+        const cyclicVal = document.getElementById('pp-table-cyclic').checked === true;
         const ev = evName === '(none)' ? null : evName;
         pushHistory();
         let dsl = getDsl();
@@ -3144,9 +3150,9 @@ function renderTable(parsed) {
           else { targetId = stateDotPath(target); }
           if (existing) {
             dsl = replaceTransition(existing.from, existing.to, existing.event, existing.guard,
-              stateDotPath(stateId), targetId, ev, guard || null, action || null, kind, dsl);
+              stateDotPath(stateId), targetId, ev, guard || null, action || null, kind, dsl, cyclicVal);
           } else {
-            dsl = addTransition(stateDotPath(stateId), targetId, ev, guard || null, action || null, kind, dsl);
+            dsl = addTransition(stateDotPath(stateId), targetId, ev, guard || null, action || null, kind, dsl, cyclicVal);
           }
         }
 

--- a/stablestate.html
+++ b/stablestate.html
@@ -487,6 +487,7 @@ function parseDSL(text) {
     notes: [],
     noteConnections: [],
     errors: [],
+    warnings: [],
     stateMap: {},
     pseudoMap: {},
     groupMap: {},
@@ -1056,6 +1057,9 @@ function validate(result) {
       if (t.guard) {
         result.errors.push({ line: t.line, msg: 'initial pseudo-state transition must not have a guard (found: [' + t.guard + '])' });
       }
+      if (t.cyclic) {
+        result.errors.push({ line: t.line, msg: 'initial pseudo-state transition must not have @cyclic' });
+      }
     }
   }
 
@@ -1068,6 +1072,9 @@ function validate(result) {
       if (t.event) {
         result.errors.push({ line: t.line, msg: 'choice pseudo-state transition must not have an event (found: ' + t.event + ')' });
       }
+      if (t.cyclic) {
+        result.errors.push({ line: t.line, msg: 'choice pseudo-state transition must not have @cyclic' });
+      }
       if (!t.guard) {
         guardlessCount++;
       }
@@ -1075,6 +1082,24 @@ function validate(result) {
     if (guardlessCount > 1) {
       result.errors.push({ line: ps.line, msg: 'choice pseudo-state ' + ps.id + ' has ' + guardlessCount + ' guard-less transitions (max 1 allowed as else/default)' });
     }
+  }
+
+  // ─── W1: @cyclic transitions should have a do= activity on their source state ───
+  // Cyclic transitions model periodic guard re-evaluation, which conceptually
+  // requires a do-activity as the "thing that keeps checking". Without one the
+  // author's intent is unclear (who drives the re-check?), so flag a warning.
+  // Pseudo-state sources (initial/choice/etc.) are excluded — E1/E2/E3 own those.
+  for (const t of result.transitions) {
+    if (!t.cyclic) continue;
+    if (result.pseudoMap[t.from]) continue; // pseudo-state source — handled by E1/E2/E3
+    const src = resolveStateRef(t.from, result);
+    if (!src) continue; // unresolved ref — parser/validator already reports
+    if (src.type !== 'state') continue; // pseudo-state resolved via dot-path — skip
+    if (src.do) continue; // has do activity — no warning
+    result.warnings.push({
+      line: t.line,
+      msg: "@cyclic transition leaves state '" + t.from + "' which has no 'do=' activity; consider adding one to clarify who evaluates the guard"
+    });
   }
 
   // ─── Config constraints ───

--- a/stablestate.html
+++ b/stablestate.html
@@ -2636,6 +2636,175 @@ function renderSVG(parsed) {
 }
 
 // ═══════════════════════════════════════════════
+// Multiline Autocomplete Helper
+// ═══════════════════════════════════════════════
+// Attach state-name autocomplete and Tab-indent behavior to a textarea.
+// Used by pp-table-action (action cell editor) and will be reused by
+// pp-do (Task 9: do-activity editor).
+//
+// opts:
+//   stateCandidates:   () => string[]   function returning current state IDs
+//                                       for "-> " state-name completion
+//   keywordCandidates: string[]         optional keyword completions
+//                                       (e.g. `if []`, `else`, `-> `).
+//                                       When omitted/empty, keyword autocomplete
+//                                       is disabled but Tab-indent still works.
+function attachMultilineAutocomplete(ta, opts) {
+  const getStates = (opts && opts.stateCandidates) || (function() { return []; });
+  const keywords = (opts && opts.keywordCandidates) || [];
+  let acList = null, acItems = [], acIdx = -1, acPrefix = '', acStart = 0;
+
+  function getAcContext() {
+    const pos = ta.selectionStart;
+    const textBefore = ta.value.substring(0, pos);
+    const lineStart = textBefore.lastIndexOf('\n') + 1;
+    const line = textBefore.substring(lineStart);
+    // Check for "-> prefix" (state name completion)
+    const arrowMatch = line.match(/->\s*(\S*)$/);
+    if (arrowMatch) return { type: 'state', prefix: arrowMatch[1], start: pos - arrowMatch[1].length };
+    // Check for keyword at line start (after optional indent)
+    const kwMatch = line.match(/^(\s*)(\S*)$/);
+    if (kwMatch && kwMatch[2].length > 0) return { type: 'keyword', prefix: kwMatch[2], start: pos - kwMatch[2].length };
+    return null;
+  }
+
+  function buildCandidates(type, prefix) {
+    if (type === 'state') {
+      return getStates();
+    }
+    if (type === 'keyword') {
+      return keywords;
+    }
+    return [];
+  }
+
+  function getCaretCoords() {
+    // Mirror element technique: copy textarea content into a hidden div,
+    // place a marker span at cursor position, measure its offset
+    const mirror = document.createElement('div');
+    const cs = getComputedStyle(ta);
+    ['fontFamily','fontSize','fontWeight','lineHeight','letterSpacing','wordSpacing',
+     'textIndent','whiteSpace','wordWrap','overflowWrap','padding','borderWidth','boxSizing'
+    ].forEach(p => mirror.style[p] = cs[p]);
+    mirror.style.position = 'absolute';
+    mirror.style.left = '-9999px';
+    mirror.style.top = '0';
+    mirror.style.width = cs.width;
+    mirror.style.overflow = 'hidden';
+    const pos = ta.selectionStart;
+    const textBefore = ta.value.substring(0, pos);
+    const textAfter = ta.value.substring(pos);
+    mirror.textContent = textBefore;
+    const marker = document.createElement('span');
+    marker.textContent = textAfter || '.';
+    mirror.appendChild(marker);
+    document.body.appendChild(mirror);
+    const markerRect = marker.getBoundingClientRect();
+    const mirrorRect = mirror.getBoundingClientRect();
+    const x = markerRect.left - mirrorRect.left;
+    const y = markerRect.top - mirrorRect.top - ta.scrollTop;
+    document.body.removeChild(mirror);
+    return { x: x, y: y };
+  }
+
+  function showAc(candidates) {
+    hideAc();
+    if (candidates.length === 0) return;
+    acList = document.createElement('div');
+    acList.className = 'ac-list';
+    acList.style.position = 'absolute';
+    // Position at caret
+    const caret = getCaretCoords();
+    const taRect = ta.getBoundingClientRect();
+    const panelRect = ta.parentNode.getBoundingClientRect();
+    acList.style.left = (taRect.left - panelRect.left + caret.x) + 'px';
+    acList.style.top = (taRect.top - panelRect.top + caret.y + parseInt(getComputedStyle(ta).lineHeight) || 18) + 'px';
+    acList.style.width = 'auto';
+    acList.style.minWidth = '120px';
+    acItems = candidates.slice(0, 5);
+    acIdx = 0;
+    for (let i = 0; i < acItems.length; i++) {
+      const div = document.createElement('div');
+      div.className = 'ac-item' + (i === 0 ? ' active' : '');
+      div.textContent = acItems[i];
+      div.addEventListener('mousedown', function(ev) { ev.preventDefault(); acceptAc(i); });
+      acList.appendChild(div);
+    }
+    ta.parentNode.style.position = 'relative';
+    ta.parentNode.appendChild(acList);
+  }
+
+  function hideAc() {
+    if (acList && acList.parentNode) acList.parentNode.removeChild(acList);
+    acList = null; acItems = []; acIdx = -1;
+  }
+
+  function acceptAc(idx) {
+    const val = acItems[idx];
+    const before = ta.value.substring(0, acStart);
+    const after = ta.value.substring(ta.selectionStart);
+    ta.value = before + val + after;
+    // Place cursor inside [] if keyword has brackets
+    const bracketPos = val.indexOf('[]');
+    if (bracketPos >= 0) {
+      ta.selectionStart = ta.selectionEnd = acStart + bracketPos + 1;
+    } else {
+      ta.selectionStart = ta.selectionEnd = acStart + val.length;
+    }
+    hideAc();
+  }
+
+  function updateAc() {
+    const ctx = getAcContext();
+    if (!ctx || ctx.prefix.length === 0) { hideAc(); return; }
+    acPrefix = ctx.prefix.toLowerCase();
+    acStart = ctx.start;
+    const all = buildCandidates(ctx.type, ctx.prefix);
+    const filtered = all.filter(c => c.toLowerCase().startsWith(acPrefix));
+    if (filtered.length > 0) showAc(filtered);
+    else hideAc();
+  }
+
+  ta.addEventListener('input', updateAc);
+
+  ta.addEventListener('keydown', function(e) {
+    if (acList) {
+      if (e.key === 'Tab' || e.key === 'Enter') {
+        e.preventDefault();
+        if (acIdx >= 0) acceptAc(acIdx);
+        return;
+      }
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        acIdx = Math.min(acIdx + 1, acItems.length - 1);
+        acList.querySelectorAll('.ac-item').forEach((el, i) => el.classList.toggle('active', i === acIdx));
+        return;
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        acIdx = Math.max(acIdx - 1, 0);
+        acList.querySelectorAll('.ac-item').forEach((el, i) => el.classList.toggle('active', i === acIdx));
+        return;
+      }
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        hideAc();
+        return;
+      }
+    } else {
+      // Tab inserts 2 spaces when no autocomplete showing
+      if (e.key === 'Tab') {
+        e.preventDefault();
+        const start = this.selectionStart;
+        this.value = this.value.substring(0, start) + '  ' + this.value.substring(this.selectionEnd);
+        this.selectionStart = this.selectionEnd = start + 2;
+        return;
+      }
+    }
+  });
+}
+
+// ═══════════════════════════════════════════════
 // Table Renderer
 // ═══════════════════════════════════════════════
 function renderTable(parsed) {
@@ -3021,160 +3190,16 @@ function renderTable(parsed) {
         });
       }
 
-      // Autocomplete for state names after "-> "
+      // Autocomplete for state names after "-> " and keyword completion
+      // (extracted into attachMultilineAutocomplete helper; Task 9 will reuse
+      //  it for the pp-do textarea, passing only stateCandidates.)
       const actionTa = document.getElementById('pp-table-action');
-      let acList = null, acItems = [], acIdx = -1, acPrefix = '', acStart = 0;
-
-      function getAcContext() {
-        const pos = actionTa.selectionStart;
-        const textBefore = actionTa.value.substring(0, pos);
-        const lineStart = textBefore.lastIndexOf('\n') + 1;
-        const line = textBefore.substring(lineStart);
-        // Check for "-> prefix" (state name completion)
-        const arrowMatch = line.match(/->\s*(\S*)$/);
-        if (arrowMatch) return { type: 'state', prefix: arrowMatch[1], start: pos - arrowMatch[1].length };
-        // Check for keyword at line start (after optional indent)
-        const kwMatch = line.match(/^(\s*)(\S*)$/);
-        if (kwMatch && kwMatch[2].length > 0) return { type: 'keyword', prefix: kwMatch[2], start: pos - kwMatch[2].length };
-        return null;
-      }
-
       const AC_KEYWORDS = ['if []', 'elif []', 'else if []', 'else', '-> '];
-
-      function buildCandidates(type, prefix) {
-        if (type === 'state') {
-          if (!parsed) return [];
-          return parsed.states.map(s => s.path || s.id);
-        }
-        if (type === 'keyword') {
-          return AC_KEYWORDS;
-        }
-        return [];
-      }
-
-      function getCaretCoords() {
-        // Mirror element technique: copy textarea content into a hidden div,
-        // place a marker span at cursor position, measure its offset
-        const mirror = document.createElement('div');
-        const cs = getComputedStyle(actionTa);
-        ['fontFamily','fontSize','fontWeight','lineHeight','letterSpacing','wordSpacing',
-         'textIndent','whiteSpace','wordWrap','overflowWrap','padding','borderWidth','boxSizing'
-        ].forEach(p => mirror.style[p] = cs[p]);
-        mirror.style.position = 'absolute';
-        mirror.style.left = '-9999px';
-        mirror.style.top = '0';
-        mirror.style.width = cs.width;
-        mirror.style.overflow = 'hidden';
-        const pos = actionTa.selectionStart;
-        const textBefore = actionTa.value.substring(0, pos);
-        const textAfter = actionTa.value.substring(pos);
-        mirror.textContent = textBefore;
-        const marker = document.createElement('span');
-        marker.textContent = textAfter || '.';
-        mirror.appendChild(marker);
-        document.body.appendChild(mirror);
-        const markerRect = marker.getBoundingClientRect();
-        const mirrorRect = mirror.getBoundingClientRect();
-        const x = markerRect.left - mirrorRect.left;
-        const y = markerRect.top - mirrorRect.top - actionTa.scrollTop;
-        document.body.removeChild(mirror);
-        return { x: x, y: y };
-      }
-
-      function showAc(candidates) {
-        hideAc();
-        if (candidates.length === 0) return;
-        acList = document.createElement('div');
-        acList.className = 'ac-list';
-        acList.style.position = 'absolute';
-        // Position at caret
-        const caret = getCaretCoords();
-        const taRect = actionTa.getBoundingClientRect();
-        const panelRect = actionTa.parentNode.getBoundingClientRect();
-        acList.style.left = (taRect.left - panelRect.left + caret.x) + 'px';
-        acList.style.top = (taRect.top - panelRect.top + caret.y + parseInt(getComputedStyle(actionTa).lineHeight) || 18) + 'px';
-        acList.style.width = 'auto';
-        acList.style.minWidth = '120px';
-        acItems = candidates.slice(0, 5);
-        acIdx = 0;
-        for (let i = 0; i < acItems.length; i++) {
-          const div = document.createElement('div');
-          div.className = 'ac-item' + (i === 0 ? ' active' : '');
-          div.textContent = acItems[i];
-          div.addEventListener('mousedown', function(ev) { ev.preventDefault(); acceptAc(i); });
-          acList.appendChild(div);
-        }
-        actionTa.parentNode.style.position = 'relative';
-        actionTa.parentNode.appendChild(acList);
-      }
-
-      function hideAc() {
-        if (acList && acList.parentNode) acList.parentNode.removeChild(acList);
-        acList = null; acItems = []; acIdx = -1;
-      }
-
-      function acceptAc(idx) {
-        const val = acItems[idx];
-        const before = actionTa.value.substring(0, acStart);
-        const after = actionTa.value.substring(actionTa.selectionStart);
-        actionTa.value = before + val + after;
-        // Place cursor inside [] if keyword has brackets
-        const bracketPos = val.indexOf('[]');
-        if (bracketPos >= 0) {
-          actionTa.selectionStart = actionTa.selectionEnd = acStart + bracketPos + 1;
-        } else {
-          actionTa.selectionStart = actionTa.selectionEnd = acStart + val.length;
-        }
-        hideAc();
-      }
-
-      function updateAc() {
-        const ctx = getAcContext();
-        if (!ctx || ctx.prefix.length === 0) { hideAc(); return; }
-        acPrefix = ctx.prefix.toLowerCase();
-        acStart = ctx.start;
-        const all = buildCandidates(ctx.type, ctx.prefix);
-        const filtered = all.filter(c => c.toLowerCase().startsWith(acPrefix));
-        if (filtered.length > 0) showAc(filtered);
-        else hideAc();
-      }
-
-      actionTa.addEventListener('input', updateAc);
-
-      actionTa.addEventListener('keydown', function(e) {
-        if (acList) {
-          if (e.key === 'Tab' || e.key === 'Enter') {
-            e.preventDefault();
-            if (acIdx >= 0) acceptAc(acIdx);
-            return;
-          }
-          if (e.key === 'ArrowDown') {
-            e.preventDefault();
-            acIdx = Math.min(acIdx + 1, acItems.length - 1);
-            acList.querySelectorAll('.ac-item').forEach((el, i) => el.classList.toggle('active', i === acIdx));
-            return;
-          }
-          if (e.key === 'ArrowUp') {
-            e.preventDefault();
-            acIdx = Math.max(acIdx - 1, 0);
-            acList.querySelectorAll('.ac-item').forEach((el, i) => el.classList.toggle('active', i === acIdx));
-            return;
-          }
-          if (e.key === 'Escape') {
-            e.preventDefault();
-            hideAc();
-            return;
-          }
-        } else {
-          // Tab inserts 2 spaces when no autocomplete showing
-          if (e.key === 'Tab') {
-            e.preventDefault();
-            const start = this.selectionStart;
-            this.value = this.value.substring(0, start) + '  ' + this.value.substring(this.selectionEnd);
-            this.selectionStart = this.selectionEnd = start + 2;
-            return;
-          }
-        }
+      attachMultilineAutocomplete(actionTa, {
+        stateCandidates: function() {
+          return parsed ? parsed.states.map(s => s.path || s.id) : [];
+        },
+        keywordCandidates: AC_KEYWORDS
       });
 
       document.getElementById('pp-table-apply').addEventListener('click', function() {

--- a/stablestate.html
+++ b/stablestate.html
@@ -859,6 +859,9 @@ function parseDSL(text) {
         // @cyclic is orthogonal to @kind — both may appear, in either order.
         // Loop strips whichever suffix currently terminates `remaining` until
         // neither matches, which handles "@kind @cyclic" and "@cyclic @kind".
+        // NOTE: We use a local shape here instead of stripTransitionSuffixes()
+        // because we need to capture kind/isCyclic into locals. The strip-only
+        // variant of this loop is used by removeTransition/replaceTransition.
         let suffixChanged = true;
         while (suffixChanged) {
           suffixChanged = false;
@@ -1219,6 +1222,23 @@ function addTransition(from, to, event, guard, action, kind, dsl, cyclic) {
   return dsl + '\n' + line;
 }
 
+// Strip trailing @cyclic and @(local|external|internal) suffixes from a transition
+// detail string, in any order. Used by removeTransition and replaceTransition for
+// match comparisons (capture-less strip). The parseDSL body uses a shape variant
+// that captures kind/isCyclic and is NOT consolidated here.
+function stripTransitionSuffixes(s) {
+  let changed = true;
+  while (changed) {
+    changed = false;
+    const before = s;
+    s = s.replace(/@cyclic\s*$/, '').trim();
+    if (s !== before) { changed = true; continue; }
+    s = s.replace(/@(local|external|internal)\s*$/, '').trim();
+    if (s !== before) changed = true;
+  }
+  return s;
+}
+
 // Remove a matching transition line (match by from, to, event, guard)
 function removeTransition(from, to, event, guard, dsl) {
   const lines = dsl.split('\n');
@@ -1233,15 +1253,7 @@ function removeTransition(from, to, event, guard, dsl) {
       if (rest.startsWith(':')) {
         let detail = rest.slice(1).trim();
         // Remove @cyclic and @kind suffixes (either order)
-        let stripped = true;
-        while (stripped) {
-          stripped = false;
-          const before = detail;
-          detail = detail.replace(/@cyclic\s*$/, '').trim();
-          if (detail !== before) { stripped = true; continue; }
-          detail = detail.replace(/@(local|external|internal)\s*$/, '').trim();
-          if (detail !== before) stripped = true;
-        }
+        detail = stripTransitionSuffixes(detail);
         // Remove action
         const slashIdx = detail.indexOf('/');
         if (slashIdx !== -1) detail = detail.slice(0, slashIdx).trim();
@@ -1306,15 +1318,7 @@ function replaceTransition(oldFrom, oldTo, oldEvent, oldGuard, newFrom, newTo, n
         let detail = rest.slice(1).trim();
         // Strip @cyclic and @kind suffixes (either order) before extracting
         // event/guard for the match comparison.
-        let stripped = true;
-        while (stripped) {
-          stripped = false;
-          const before = detail;
-          detail = detail.replace(/@cyclic\s*$/, '').trim();
-          if (detail !== before) { stripped = true; continue; }
-          detail = detail.replace(/@(local|external|internal)\s*$/, '').trim();
-          if (detail !== before) stripped = true;
-        }
+        detail = stripTransitionSuffixes(detail);
         const slashIdx = detail.indexOf('/');
         if (slashIdx !== -1) detail = detail.slice(0, slashIdx).trim();
         const gm = detail.match(/\[([^\]]*)\]/);

--- a/stablestate.html
+++ b/stablestate.html
@@ -1758,6 +1758,14 @@ function getAbsolutePos(element, parsed) {
 }
 
 // ═══════════════════════════════════════════════
+// Cyclic transition visual defaults
+// (used by renderSVG, renderTable, exportPlantUML)
+// ═══════════════════════════════════════════════
+const CYCLIC_COLOR = '#F59E0B';    // amber
+const CYCLIC_DASH  = '6,4';
+const CYCLIC_GLYPH = '⟳';          // U+27F3 CLOCKWISE OPEN CIRCLE ARROW
+
+// ═══════════════════════════════════════════════
 // SVG Renderer
 // ═══════════════════════════════════════════════
 function renderSVG(parsed) {
@@ -1768,11 +1776,6 @@ function renderSVG(parsed) {
   const sans = "'IBM Plex Sans','Noto Sans JP',sans-serif";
   const mono = "'IBM Plex Mono',monospace";
   const shadow = 'filter="drop-shadow(2px 2px 4px rgba(0,0,0,0.4))"';
-
-  // Cyclic transition visual defaults (used when user has not overridden via color=/style=)
-  const CYCLIC_COLOR = '#F59E0B';    // amber
-  const CYCLIC_DASH  = '6,4';
-  const CYCLIC_GLYPH = '⟳';          // U+27F3 CLOCKWISE OPEN CIRCLE ARROW
 
   let svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${canvas.width*zoom}" height="${canvas.height*zoom}" viewBox="0 0 ${canvas.width} ${canvas.height}">`;
 

--- a/stablestate.html
+++ b/stablestate.html
@@ -1769,6 +1769,11 @@ function renderSVG(parsed) {
   const mono = "'IBM Plex Mono',monospace";
   const shadow = 'filter="drop-shadow(2px 2px 4px rgba(0,0,0,0.4))"';
 
+  // Cyclic transition visual defaults (used when user has not overridden via color=/style=)
+  const CYCLIC_COLOR = '#F59E0B';    // amber
+  const CYCLIC_DASH  = '6,4';
+  const CYCLIC_GLYPH = '⟳';          // U+27F3 CLOCKWISE OPEN CIRCLE ARROW
+
   let svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${canvas.width*zoom}" height="${canvas.height*zoom}" viewBox="0 0 ${canvas.width} ${canvas.height}">`;
 
   // ─── 1. Grid pattern ───
@@ -1968,7 +1973,7 @@ function renderSVG(parsed) {
     svg += `<marker id="${mid}" markerWidth="10" markerHeight="8" refX="10" refY="4" orient="auto"><path d="M0,0 L10,4 L0,8 Z" fill="${c}"/></marker>`;
   }
   // Cyclic arrow marker (amber, for transitions with @cyclic flag)
-  svg += `<marker id="arr-cyclic" markerWidth="10" markerHeight="8" refX="10" refY="4" orient="auto"><path d="M0,0 L10,4 L0,8 Z" fill="#F59E0B"/></marker>`;
+  svg += `<marker id="arr-cyclic" markerWidth="10" markerHeight="8" refX="10" refY="4" orient="auto"><path d="M0,0 L10,4 L0,8 Z" fill="${CYCLIC_COLOR}"/></marker>`;
   svg += `</defs>`;
 
   // Helper: get bounding box {x, y, w, h} in pixels for a state or pseudo-state
@@ -2384,14 +2389,13 @@ function renderSVG(parsed) {
     // Cyclic default stroke color is amber; user's explicit color= wins
     let sc;
     if (tr.color) sc = tr.color;
-    else if (tr.cyclic) sc = '#F59E0B';
+    else if (tr.cyclic) sc = CYCLIC_COLOR;
     else sc = '#89DDFF';
     // Cyclic default line is dashed; user's explicit style= wins
     let dashAttr;
     if (tr.style === 'dashed') dashAttr = ' stroke-dasharray="6 3"';
-    else if (tr.style === 'dotted') dashAttr = ' stroke-dasharray="2,3"';
-    else if (tr.style === 'solid') dashAttr = '';
-    else if (tr.cyclic) dashAttr = ' stroke-dasharray="6,4"';
+    else if (tr.style === 'solid') dashAttr = '';  // explicit: beats cyclic fallthrough below
+    else if (tr.cyclic) dashAttr = ` stroke-dasharray="${CYCLIC_DASH}"`;
     else dashAttr = '';
     // Cyclic uses a dedicated amber marker unless user provided a custom color
     const _amid = (tr.cyclic && !tr.color) ? 'arr-cyclic' : ('ah_' + sc.replace(/[^a-zA-Z0-9]/g, ''));
@@ -2457,7 +2461,7 @@ function renderSVG(parsed) {
       const labelLines = [];
       // Cyclic marker prefix — always shown for @cyclic transitions, cannot be opted out
       if (tr.cyclic) {
-        labelLines.push({ text: '⟳', color: '#F59E0B', size: 11 });
+        labelLines.push({ text: CYCLIC_GLYPH, color: CYCLIC_COLOR, size: 11 });
       }
       if (tr.event) labelLines.push({ text: tr.event, color: '#FFCB6B', size: 10 });
       const guardAction = [];

--- a/stablestate.html
+++ b/stablestate.html
@@ -1967,6 +1967,8 @@ function renderSVG(parsed) {
     const mid = 'ah_' + c.replace(/[^a-zA-Z0-9]/g, '');
     svg += `<marker id="${mid}" markerWidth="10" markerHeight="8" refX="10" refY="4" orient="auto"><path d="M0,0 L10,4 L0,8 Z" fill="${c}"/></marker>`;
   }
+  // Cyclic arrow marker (amber, for transitions with @cyclic flag)
+  svg += `<marker id="arr-cyclic" markerWidth="10" markerHeight="8" refX="10" refY="4" orient="auto"><path d="M0,0 L10,4 L0,8 Z" fill="#F59E0B"/></marker>`;
   svg += `</defs>`;
 
   // Helper: get bounding box {x, y, w, h} in pixels for a state or pseudo-state
@@ -2379,9 +2381,20 @@ function renderSVG(parsed) {
 
     // Build SVG path
     const sw = tr.width || 1.5;
-    const sc = tr.color || '#89DDFF';
-    const dashAttr = tr.style === 'dashed' ? ' stroke-dasharray="6 3"' : '';
-    const _amid = 'ah_' + sc.replace(/[^a-zA-Z0-9]/g, '');
+    // Cyclic default stroke color is amber; user's explicit color= wins
+    let sc;
+    if (tr.color) sc = tr.color;
+    else if (tr.cyclic) sc = '#F59E0B';
+    else sc = '#89DDFF';
+    // Cyclic default line is dashed; user's explicit style= wins
+    let dashAttr;
+    if (tr.style === 'dashed') dashAttr = ' stroke-dasharray="6 3"';
+    else if (tr.style === 'dotted') dashAttr = ' stroke-dasharray="2,3"';
+    else if (tr.style === 'solid') dashAttr = '';
+    else if (tr.cyclic) dashAttr = ' stroke-dasharray="6,4"';
+    else dashAttr = '';
+    // Cyclic uses a dedicated amber marker unless user provided a custom color
+    const _amid = (tr.cyclic && !tr.color) ? 'arr-cyclic' : ('ah_' + sc.replace(/[^a-zA-Z0-9]/g, ''));
     if (crossings.length === 0) {
       // Simple polyline
       const pts = route.map(p => `${p.x},${p.y}`).join(' ');
@@ -2424,7 +2437,7 @@ function renderSVG(parsed) {
 
     // Labels — positioned at each route's own midpoint (routes are separated by port distribution)
     const isChoiceElse = !tr.event && !tr.guard && parsed.pseudoMap[tr.from] && parsed.pseudoMap[tr.from].type === 'choice';
-    const hasLabel = tr.event || tr.guard || tr.action || isChoiceElse;
+    const hasLabel = tr.event || tr.guard || tr.action || isChoiceElse || tr.cyclic;
     if (hasLabel) {
       const mid = routeMidpoint(route);
       // Determine if the segment at midpoint is horizontal or vertical
@@ -2442,6 +2455,10 @@ function renderSVG(parsed) {
       // For horizontal segments: label above/below the line
       // For vertical segments: label to the left/right of the line
       const labelLines = [];
+      // Cyclic marker prefix — always shown for @cyclic transitions, cannot be opted out
+      if (tr.cyclic) {
+        labelLines.push({ text: '⟳', color: '#F59E0B', size: 11 });
+      }
       if (tr.event) labelLines.push({ text: tr.event, color: '#FFCB6B', size: 10 });
       const guardAction = [];
       if (tr.guard) {

--- a/stablestate.html
+++ b/stablestate.html
@@ -3766,6 +3766,9 @@ function getExportSVGString() {
   // `fill="#6366F1" stroke="#fff"` (indigo for states/pseudo-states) or
   // `fill="#F59E0B" stroke="#fff"` (amber for notes). Both are strictly
   // editor UI chrome and must not be baked into exported SVG/PNG artifacts.
+  // Note: the Task 2 `<marker id="arr-cyclic">` (also amber #F59E0B) is a
+  // <marker> with a <path> child, not a rect, and has no `data-resize`
+  // attribute, so neither selector matches it — cyclic arrows survive export.
   clone.querySelectorAll('[data-resize]').forEach(el => el.remove());
   clone.querySelectorAll('rect[fill="#6366F1"][stroke="#fff"], rect[fill="#F59E0B"][stroke="#fff"]').forEach(el => el.remove());
   return new XMLSerializer().serializeToString(clone);
@@ -3922,12 +3925,18 @@ function exportPlantUML(p) {
   );
 
   function renderLabel(tr) {
-    if (!tr.event && !tr.guard && !tr.action) return '';
     const parts = [];
+    if (tr.cyclic) parts.push(CYCLIC_GLYPH);
     if (tr.event) parts.push(tr.event);
     if (tr.guard) parts.push('[' + tr.guard + ']');
     if (tr.action) parts.push('/ ' + tr.action);
+    if (parts.length === 0) return '';
     return ' : ' + parts.join(' ');
+  }
+  function arrowStr(tr) {
+    // Cyclic transitions render with amber dashed arrow to mirror the SVG
+    // styling (Task 2). Non-cyclic stays as the default PlantUML `-->`.
+    return tr.cyclic ? ('-[' + CYCLIC_COLOR + ',dashed]->') : '-->';
   }
   function renderEndpoint(ref) {
     // `from` side of initial becomes `[*]`. final stays as its id (it was
@@ -3973,7 +3982,7 @@ function exportPlantUML(p) {
       }
       // Interior transitions: all transitions whose LCA is this composite.
       for (const tr of innerTrans) {
-        lines.push(innerPad + renderEndpoint(tr.from) + ' --> ' + renderEndpoint(tr.to) + renderLabel(tr));
+        lines.push(innerPad + renderEndpoint(tr.from) + ' ' + arrowStr(tr) + ' ' + renderEndpoint(tr.to) + renderLabel(tr));
       }
       lines.push(pad + '}');
     } else {
@@ -3996,7 +4005,7 @@ function exportPlantUML(p) {
   // Root-level transitions (those whose LCA is root).
   const rootTrans = transByScope.get(null) || [];
   for (const tr of rootTrans) {
-    lines.push(renderEndpoint(tr.from) + ' --> ' + renderEndpoint(tr.to) + renderLabel(tr));
+    lines.push(renderEndpoint(tr.from) + ' ' + arrowStr(tr) + ' ' + renderEndpoint(tr.to) + renderLabel(tr));
   }
 
   lines.push('@enduml');

--- a/stablestate.html
+++ b/stablestate.html
@@ -2783,7 +2783,10 @@ function renderTable(parsed) {
         return fromEl && (fromEl.path === lc.id || fromEl.id === lc.id);
       });
       const val = matching.length > 0 && matching[0].guard ? matching[0].guard : '-';
-      bodyHtml += `<td class="table-editable" data-field="guard" data-state="${lc.id}" data-event="${esc(evName)}" style="cursor:pointer;color:#C3E88D">${esc(val).replace(/\\n/g, '<br>')}</td>`;
+      const isCyclic = matching.length > 0 && matching[0].cyclic === true;
+      const cyclicPrefix = isCyclic ? (CYCLIC_GLYPH + ' ') : '';
+      const cellColor = isCyclic ? CYCLIC_COLOR : '#C3E88D';
+      bodyHtml += `<td class="table-editable" data-field="guard" data-state="${lc.id}" data-event="${esc(evName)}" style="cursor:pointer;color:${cellColor}">${cyclicPrefix}${esc(val).replace(/\\n/g, '<br>')}</td>`;
     }
     bodyHtml += '</tr>';
 
@@ -2799,7 +2802,10 @@ function renderTable(parsed) {
         const ifElse = actionToIfElse(matching[0].to, parsed);
         if (ifElse) val = ifElse;
       }
-      bodyHtml += `<td class="table-editable" data-field="action" data-state="${lc.id}" data-event="${esc(evName)}" style="cursor:pointer;color:#C3E88D;white-space:pre-wrap">${esc(val).replace(/\\n/g, '\n')}</td>`;
+      const isCyclic = matching.length > 0 && matching[0].cyclic === true;
+      const cyclicPrefix = isCyclic ? (CYCLIC_GLYPH + ' ') : '';
+      const cellColor = isCyclic ? CYCLIC_COLOR : '#C3E88D';
+      bodyHtml += `<td class="table-editable" data-field="action" data-state="${lc.id}" data-event="${esc(evName)}" style="cursor:pointer;color:${cellColor};white-space:pre-wrap">${cyclicPrefix}${esc(val).replace(/\\n/g, '\n')}</td>`;
     }
     bodyHtml += '</tr>';
 
@@ -2831,7 +2837,10 @@ function renderTable(parsed) {
           }
         }
       }
-      bodyHtml += `<td class="table-editable" data-field="target" data-state="${lc.id}" data-event="${esc(evName)}" style="cursor:pointer">${esc(val)}</td>`;
+      const isCyclic = matching.length > 0 && matching[0].cyclic === true;
+      const cyclicPrefix = isCyclic ? (CYCLIC_GLYPH + ' ') : '';
+      const cyclicStyle = isCyclic ? `;color:${CYCLIC_COLOR}` : '';
+      bodyHtml += `<td class="table-editable" data-field="target" data-state="${lc.id}" data-event="${esc(evName)}" style="cursor:pointer${cyclicStyle}">${cyclicPrefix}${esc(val)}</td>`;
     }
     bodyHtml += '</tr>';
   }

--- a/stablestate.html
+++ b/stablestate.html
@@ -1195,38 +1195,57 @@ function updateSize(type, id, nw, nh, dsl, lineNum) {
 }
 
 // Add or replace a property (key=value) on an element line
+// Format a prop value for DSL emission: quote if it contains whitespace or
+// the 2-char `\n` escape literal, otherwise emit bare. Embedded `"` are
+// escaped as `\"` for the quoted form.
+function formatPropValue(val) {
+  if (val == null) return '';
+  const s = String(val);
+  if (s === '') return '';
+  // Need quotes if whitespace (including raw \n/\t) OR the 2-char \n escape
+  // OR contains a double quote itself.
+  if (/[\s"]|\\n/.test(s)) {
+    return '"' + s.replace(/"/g, '\\"') + '"';
+  }
+  return s;
+}
+
 function updateProp(type, id, prop, val, dsl, lineNum) {
+  const emit = formatPropValue(val);
+  // Match either a quoted value (with \" escapes) or a bare non-whitespace token,
+  // mirroring parseProps so we can replace an existing quoted prop in place.
+  const propValPat = `(?:"(?:[^"\\\\]|\\\\.)*"|\\S+)`;
   if (lineNum != null) {
     const lines = dsl.split('\n');
     const idx = lineNum - 1;
     if (idx >= 0 && idx < lines.length) {
-      const reExist = new RegExp(`^(\\s*${type}\\s+${id}\\s+.*)\\b${prop}=\\S+(.*$)`);
+      const reExist = new RegExp(`^(\\s*${type}\\s+${id}\\s+.*)\\b${prop}=${propValPat}(.*$)`);
       if (reExist.test(lines[idx])) {
-        lines[idx] = lines[idx].replace(reExist, `$1${prop}=${val}$2`);
+        lines[idx] = lines[idx].replace(reExist, `$1${prop}=${emit}$2`);
       } else {
         const trimEnd = lines[idx].trimEnd();
         if (trimEnd.endsWith('{')) {
-          lines[idx] = trimEnd.slice(0, -1).trimEnd() + ` ${prop}=${val} {`;
+          lines[idx] = trimEnd.slice(0, -1).trimEnd() + ` ${prop}=${emit} {`;
         } else {
-          lines[idx] = trimEnd + ` ${prop}=${val}`;
+          lines[idx] = trimEnd + ` ${prop}=${emit}`;
         }
       }
     }
     return lines.join('\n');
   }
   // First try to replace existing prop
-  const reExist = new RegExp(`^(\\s*${type}\\s+${id}\\s+.*)\\b${prop}=\\S+(.*$)`, 'm');
+  const reExist = new RegExp(`^(\\s*${type}\\s+${id}\\s+.*)\\b${prop}=${propValPat}(.*$)`, 'm');
   if (reExist.test(dsl)) {
-    return dsl.replace(reExist, `$1${prop}=${val}$2`);
+    return dsl.replace(reExist, `$1${prop}=${emit}$2`);
   }
   // Prop doesn't exist — append before trailing { or at end of line
   const reLine = new RegExp(`^(\\s*${type}\\s+${id}\\s+.+)$`, 'm');
   return dsl.replace(reLine, function(wholeLine) {
     const trimEnd = wholeLine.trimEnd();
     if (trimEnd.endsWith('{')) {
-      return trimEnd.slice(0, -1).trimEnd() + ` ${prop}=${val} {`;
+      return trimEnd.slice(0, -1).trimEnd() + ` ${prop}=${emit} {`;
     }
-    return trimEnd + ` ${prop}=${val}`;
+    return trimEnd + ` ${prop}=${emit}`;
   });
 }
 
@@ -3307,7 +3326,7 @@ function renderProps() {
       html += `</div>`;
       html += `<div class="prop-section"><div class="prop-label">Actions</div>`;
       html += `<div class="prop-row"><input class="prop-input" id="pp-entry" value="${esc(st.entry || '')}" placeholder="entry"></div>`;
-      html += `<div class="prop-row"><input class="prop-input" id="pp-do" value="${esc(st.do || '')}" placeholder="do"></div>`;
+      html += `<div class="prop-row"><textarea class="prop-input" id="pp-do" placeholder="do" style="min-height:40px;resize:vertical;font-family:Consolas,monospace;font-size:11px;line-height:1.4;white-space:pre">${esc((st.do || '').replace(/\\n/g, '\n'))}</textarea></div>`;
       html += `<div class="prop-row"><input class="prop-input" id="pp-exit" value="${esc(st.exit || '')}" placeholder="exit"></div>`;
       html += `</div>`;
       // Color palette
@@ -3633,24 +3652,55 @@ function renderProps() {
   if (pph) pph.addEventListener('change', handleSizeChange);
 
   // Actions (entry, do, exit)
-  ['entry', 'do', 'exit'].forEach(function(field) {
+  // pp-do is a textarea (Task 9) — supports multi-line content with \n escape
+  // for DSL storage. pp-entry and pp-exit remain single-line <input>.
+  function saveActionField(field, rawValue) {
+    const info = getElTypeAndId();
+    if (!info) return;
+    pushHistory();
+    let dsl = getDsl();
+    // For pp-do textarea: escape real newlines to \n 2-char literal before
+    // writing back to the DSL. updateProp/formatPropValue then decides whether
+    // to quote the value.
+    const val = (field === 'do')
+      ? rawValue.replace(/\n/g, '\\n').trim()
+      : rawValue.trim();
+    if (val) {
+      dsl = updateProp(info.type, info.id, field, val, dsl, info.line);
+    } else {
+      // Remove the property. Match either a quoted value (with \" escapes) or
+      // a bare non-whitespace token, so we can also strip previously-quoted
+      // values (e.g. do="multi line").
+      const re = new RegExp(
+        `(^\\s*${info.type}\\s+${info.id}\\s+.*)\\b${field}=(?:"(?:[^"\\\\]|\\\\.)*"|\\S+)`,
+        'm'
+      );
+      dsl = dsl.replace(re, '$1');
+    }
+    setDsl(dsl);
+    refreshView();
+  }
+  ['entry', 'exit'].forEach(function(field) {
     propChange('pp-' + field, function() {
-      const info = getElTypeAndId();
-      if (!info) return;
-      pushHistory();
-      let dsl = getDsl();
-      const val = this.value.trim();
-      if (val) {
-        dsl = updateProp(info.type, info.id, field, val, dsl, info.line);
-      } else {
-        // Remove the property by replacing with empty — use regex to strip
-        const re = new RegExp(`(^\\s*${info.type}\\s+${info.id}\\s+.*)\\b${field}=\\S+`, 'm');
-        dsl = dsl.replace(re, '$1');
-      }
-      setDsl(dsl);
-      refreshView();
+      saveActionField(field, this.value);
     });
   });
+  // pp-do: listen on 'input' so live typing saves back (matches table-action
+  // multi-line editor UX). Also attach autocomplete helper for state names.
+  const doTa = document.getElementById('pp-do');
+  if (doTa) {
+    doTa.addEventListener('change', function() {
+      saveActionField('do', this.value);
+    });
+    if (doTa.tagName === 'TEXTAREA') {
+      attachMultilineAutocomplete(doTa, {
+        stateCandidates: function() {
+          return parsed ? parsed.states.map(s => s.path || s.id) : [];
+        }
+        // No keywordCandidates — pp-do is for state-name completion only.
+      });
+    }
+  }
 
   // Color dots
   panel.querySelectorAll('.color-dot[data-prop]').forEach(function(dot) {

--- a/stablestate.html
+++ b/stablestate.html
@@ -4100,6 +4100,13 @@ function exportPlantUML(p) {
     } else {
       lines.push(pad + 'state "' + st.label + '" as ' + st.id);
     }
+    // Task 11: emit entry/do/exit as state description lines for BOTH composite
+    // and leaf states. PlantUML treats `\n` within a description as a line break,
+    // so multiline `do` (stored as 2-char literal per Task 7 parser contract)
+    // renders naturally without further escape conversion.
+    if (st.entry) lines.push(pad + st.id + ' : entry / ' + st.entry);
+    if (st.do)    lines.push(pad + st.id + ' : do / ' + st.do);
+    if (st.exit)  lines.push(pad + st.id + ' : exit / ' + st.exit);
   }
 
   // ─── Root-level declarations ───

--- a/stablestate.html
+++ b/stablestate.html
@@ -1197,7 +1197,9 @@ function updateSize(type, id, nw, nh, dsl, lineNum) {
 // Add or replace a property (key=value) on an element line
 // Format a prop value for DSL emission: quote if it contains whitespace or
 // the 2-char `\n` escape literal, otherwise emit bare. Embedded `"` are
-// escaped as `\"` for the quoted form.
+// escaped as `\"` for the quoted form. Backslashes are NOT re-escaped here —
+// the 2-char-literal convention (`\n`, `\\`, `\t` stay as raw 2-char
+// sequences) is the contract with parseProps (see Task 7).
 function formatPropValue(val) {
   if (val == null) return '';
   const s = String(val);
@@ -3685,8 +3687,9 @@ function renderProps() {
       saveActionField(field, this.value);
     });
   });
-  // pp-do: listen on 'input' so live typing saves back (matches table-action
-  // multi-line editor UX). Also attach autocomplete helper for state names.
+  // pp-do: listen on 'change' (fires on blur/commit) to save back, consistent
+  // with pp-entry / pp-exit. attachMultilineAutocomplete also provides live
+  // autocomplete wiring for state names after the `-> ` prefix.
   const doTa = document.getElementById('pp-do');
   if (doTa) {
     doTa.addEventListener('change', function() {

--- a/stablestate.html
+++ b/stablestate.html
@@ -1908,7 +1908,12 @@ function renderSVG(parsed) {
         ay += 14;
       }
       if (st.do) {
-        svg += `<text x="${pos.x + 10}" y="${ay}" font-family="${mono}" font-size="10" fill="#888888" style="pointer-events:none">do / ${esc(st.do)}</text>`;
+        // Task 10: multiline do shows first logical line + … (U+2026). Box size unchanged.
+        // st.do contains \n as 2-char literal (Task 7 parser contract); split on '\\n'.
+        const doFirstLine = st.do.split('\\n')[0];
+        const doHasMore = st.do.indexOf('\\n') >= 0;
+        const doDisplay = doFirstLine + (doHasMore ? ' …' : '');
+        svg += `<text x="${pos.x + 10}" y="${ay}" font-family="${mono}" font-size="10" fill="#888888" style="pointer-events:none">do / ${esc(doDisplay)}</text>`;
         ay += 14;
       }
       if (st.exit) {
@@ -1968,7 +1973,12 @@ function renderSVG(parsed) {
         ay += 14;
       }
       if (st.do) {
-        svg += `<text x="${pos.x + 8}" y="${ay}" font-family="${mono}" font-size="10" fill="#888888" style="pointer-events:none">do / ${esc(st.do)}</text>`;
+        // Task 10: multiline do shows first logical line + … (U+2026). Box size unchanged.
+        // st.do contains \n as 2-char literal (Task 7 parser contract); split on '\\n'.
+        const doFirstLine = st.do.split('\\n')[0];
+        const doHasMore = st.do.indexOf('\\n') >= 0;
+        const doDisplay = doFirstLine + (doHasMore ? ' …' : '');
+        svg += `<text x="${pos.x + 8}" y="${ay}" font-family="${mono}" font-size="10" fill="#888888" style="pointer-events:none">do / ${esc(doDisplay)}</text>`;
         ay += 14;
       }
       if (st.exit) {

--- a/stablestate.html
+++ b/stablestate.html
@@ -955,10 +955,15 @@ function parseProps(propsStr, target, lineNum, errors) {
   while ((m = propRe.exec(propsStr)) !== null) {
     const key = m[1];
     let val = m[2];
-    // Unquote if fully quoted: strip outer quotes, unescape \" → " (keep \n as 2-char literal
-    // so UI layer can later convert to real newline for textarea display).
-    if (val.length >= 2 && val.charCodeAt(0) === 34 && val.charCodeAt(val.length - 1) === 34) {
+    // Unquote if fully quoted — strip outer quotes, unescape \" → ", preserve other escapes
+    if (val.length >= 2 && val[0] === '"' && val[val.length - 1] === '"') {
+      // Only \" is unescaped here. \n, \\, \t stay as 2-char literals on
+      // purpose — the textarea/PlantUML layers (Tasks 9-11) own newline handling.
       val = val.slice(1, -1).replace(/\\"/g, '"');
+    } else if (val[0] === '"') {
+      // Malformed: bare branch caught a half-quoted token (unclosed quote).
+      // Skip assignment — the E4 pass below will emit the diagnostic.
+      continue;
     }
     switch (key) {
       case 'entry': target.entry = val; break;
@@ -979,7 +984,7 @@ function parseProps(propsStr, target, lineNum, errors) {
     const unclosedRe = /(\w+)="[^"]*$/;
     const um = propsStr.match(unclosedRe);
     if (um) {
-      errors.push({ line: lineNum, msg: "L" + lineNum + ": unclosed quoted value for '" + um[1] + "'" });
+      errors.push({ line: lineNum, msg: "unclosed quoted value for '" + um[1] + "'" });
     }
   }
 }

--- a/tests/cyclic-transitions/do-editor.spec.js
+++ b/tests/cyclic-transitions/do-editor.spec.js
@@ -1,0 +1,74 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+const BASE = 'http://localhost:8765/stablestate.html';
+
+async function setDslAndGet(page, dsl) {
+  await page.evaluate((d) => {
+    const ta = document.querySelector('#editor');
+    ta.value = d;
+    ta.dispatchEvent(new Event('input', { bubbles: true }));
+  }, dsl);
+  await page.waitForTimeout(100);
+  return await page.evaluate(() => ({
+    states: parsed.states.map(s => ({ id: s.id, do: s.do })),
+    errors: (parsed.errors || []).map(e => e.msg || e)
+  }));
+}
+
+test.describe('do editor — parseProps quoted value support', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(BASE);
+    await page.waitForFunction(() => typeof parsed !== 'undefined');
+  });
+
+  test('bare do=FuncName still parses (backward compat)', async ({ page }) => {
+    const r = await setDslAndGet(page, `initial i at 1,1
+state idle "Idle" at 3,3 size 8x5 do=PollReady
+i -> idle`);
+    const s = r.states.find(x => x.id === 'idle');
+    expect(s.do).toBe('PollReady');
+  });
+
+  test('quoted do with spaces', async ({ page }) => {
+    const r = await setDslAndGet(page, `initial i at 1,1
+state idle "Idle" at 3,3 size 8x5 do="Poll ready sensors"
+i -> idle`);
+    const s = r.states.find(x => x.id === 'idle');
+    expect(s.do).toBe('Poll ready sensors');
+  });
+
+  test('quoted do with \\n literal (2-char escape, preserved)', async ({ page }) => {
+    const r = await setDslAndGet(page, `initial i at 1,1
+state idle "Idle" at 3,3 size 8x5 do="Check1\\nCheck2"
+i -> idle`);
+    const s = r.states.find(x => x.id === 'idle');
+    // \n is preserved as the 2-char sequence; UI layer will unescape for display
+    expect(s.do).toBe('Check1\\nCheck2');
+  });
+
+  test('quoted do with escaped quote \\"', async ({ page }) => {
+    const r = await setDslAndGet(page, `initial i at 1,1
+state idle "Idle" at 3,3 size 8x5 do="say \\"hello\\""
+i -> idle`);
+    const s = r.states.find(x => x.id === 'idle');
+    expect(s.do).toBe('say "hello"');
+  });
+
+  test('E4: unclosed quote raises error', async ({ page }) => {
+    const r = await setDslAndGet(page, `initial i at 1,1
+state idle "Idle" at 3,3 size 8x5 do="unclosed
+i -> idle`);
+    const matched = r.errors.find(m => /unclosed quoted value/i.test(m));
+    expect(matched).toBeTruthy();
+  });
+
+  test('quoted do with -> transition-like content', async ({ page }) => {
+    const r = await setDslAndGet(page, `initial i at 1,1
+state idle "Idle" at 3,3 size 8x5 do="if (Ready) -> active"
+state active "Active" at 14,3 size 8x5
+i -> idle`);
+    const s = r.states.find(x => x.id === 'idle');
+    expect(s.do).toBe('if (Ready) -> active');
+  });
+});

--- a/tests/cyclic-transitions/do-editor.spec.js
+++ b/tests/cyclic-transitions/do-editor.spec.js
@@ -189,3 +189,64 @@ i -> idle`);
     expect(dsl).toMatch(/do="CheckReady\\n-> active"/);
   });
 });
+
+test.describe('do editor — state box rendering', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(BASE);
+    await page.waitForFunction(() => typeof parsed !== 'undefined');
+    // Enable showActions so do text is rendered inside the state box
+    await page.evaluate(() => {
+      if (typeof showActions !== 'undefined' && !showActions) {
+        document.getElementById('btn-actions').click();
+      }
+    });
+  });
+
+  async function setDsl(page, dsl) {
+    await page.evaluate((d) => {
+      const ta = document.querySelector('#editor');
+      ta.value = d;
+      ta.dispatchEvent(new Event('input', { bubbles: true }));
+    }, dsl);
+    await page.waitForTimeout(100);
+  }
+
+  test('single-line do shows as-is (no ellipsis)', async ({ page }) => {
+    await setDsl(page, `initial i at 1,1
+state idle "Idle" at 3,3 size 8x5 do=Poll
+i -> idle`);
+    const texts = await page.evaluate(() => {
+      return Array.from(document.querySelectorAll('#svg-wrap svg text'))
+        .map(t => t.textContent).join(' | ');
+    });
+    expect(texts).toContain('do / Poll');
+    expect(texts).not.toContain('…');
+  });
+
+  test('multiline do shows first line + ellipsis', async ({ page }) => {
+    await setDsl(page, `initial i at 1,1
+state idle "Idle" at 3,3 size 8x5 do="Check1\\nCheck2\\nDispatch"
+i -> idle`);
+    const texts = await page.evaluate(() => {
+      return Array.from(document.querySelectorAll('#svg-wrap svg text'))
+        .map(t => t.textContent).join(' | ');
+    });
+    expect(texts).toMatch(/do \/ Check1.*…/);
+    // Subsequent lines must NOT appear in the state box
+    expect(texts).not.toContain('Check2');
+    expect(texts).not.toContain('Dispatch');
+  });
+
+  test('multiline do with spaces in first line rendered correctly', async ({ page }) => {
+    await setDsl(page, `initial i at 1,1
+state idle "Idle" at 3,3 size 8x5 do="if (Ready) -> active\\nPollSensors()"
+state active "Active" at 14,3 size 8x5
+i -> idle`);
+    const texts = await page.evaluate(() => {
+      return Array.from(document.querySelectorAll('#svg-wrap svg text'))
+        .map(t => t.textContent).join(' | ');
+    });
+    expect(texts).toMatch(/do \/ if \(Ready\) -> active.*…/);
+    expect(texts).not.toContain('PollSensors');
+  });
+});

--- a/tests/cyclic-transitions/do-editor.spec.js
+++ b/tests/cyclic-transitions/do-editor.spec.js
@@ -72,3 +72,120 @@ i -> idle`);
     expect(s.do).toBe('if (Ready) -> active');
   });
 });
+
+test.describe('do editor — UI textarea', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(BASE);
+    await page.waitForFunction(() => typeof parsed !== 'undefined');
+  });
+
+  async function setDslAndOpenIdle(page, dsl) {
+    await page.evaluate((d) => {
+      const ta = document.querySelector('#editor');
+      ta.value = d;
+      ta.dispatchEvent(new Event('input', { bubbles: true }));
+    }, dsl);
+    await page.waitForTimeout(100);
+    // Select idle state by assigning sel directly (mirrors mouse-click path).
+    await page.evaluate(() => {
+      // eslint-disable-next-line no-eval
+      eval('sel = [{type: "state", id: "idle"}]');
+      // eslint-disable-next-line no-eval
+      eval('renderProps()');
+    });
+    await page.waitForTimeout(50);
+  }
+
+  test('pp-do is a textarea element', async ({ page }) => {
+    await setDslAndOpenIdle(page, `initial i at 1,1
+state idle "Idle" at 3,3 size 8x5 do=Poll
+i -> idle`);
+    const tag = await page.evaluate(() => {
+      const el = document.getElementById('pp-do');
+      return el ? el.tagName : null;
+    });
+    expect(tag).toBe('TEXTAREA');
+  });
+
+  test('pp-do shows multiline content as real newlines', async ({ page }) => {
+    await setDslAndOpenIdle(page, `initial i at 1,1
+state idle "Idle" at 3,3 size 8x5 do="Check1\\nCheck2"
+i -> idle`);
+    const val = await page.evaluate(() => document.getElementById('pp-do').value);
+    expect(val).toBe('Check1\nCheck2');
+  });
+
+  test('Tab key inserts 2 spaces when autocomplete not showing', async ({ page }) => {
+    await setDslAndOpenIdle(page, `initial i at 1,1
+state idle "Idle" at 3,3 size 8x5 do=Poll
+i -> idle`);
+    await page.evaluate(() => {
+      const el = document.getElementById('pp-do');
+      el.focus();
+      el.setSelectionRange(el.value.length, el.value.length);
+    });
+    await page.keyboard.press('Tab');
+    const val = await page.evaluate(() => document.getElementById('pp-do').value);
+    expect(val).toBe('Poll  ');
+  });
+
+  test('-> prefix triggers state autocomplete dropdown', async ({ page }) => {
+    await setDslAndOpenIdle(page, `initial i at 1,1
+state idle "Idle" at 3,3 size 8x5 do=Poll
+state active "Active" at 14,3 size 8x5
+state area "Area" at 25,3 size 8x5
+i -> idle`);
+    await page.evaluate(() => {
+      const el = document.getElementById('pp-do');
+      el.focus();
+      el.value = 'Poll\n-> a';
+      el.setSelectionRange(el.value.length, el.value.length);
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await page.waitForTimeout(100);
+    const items = await page.evaluate(() => {
+      const list = document.querySelector('.ac-list');
+      if (!list) return [];
+      return Array.from(list.querySelectorAll('.ac-item')).map(el => el.textContent);
+    });
+    expect(items.length).toBeGreaterThanOrEqual(2);
+    expect(items.some(i => /active/i.test(i))).toBe(true);
+    expect(items.some(i => /area/i.test(i))).toBe(true);
+  });
+
+  test('Enter in autocomplete confirms selection', async ({ page }) => {
+    await setDslAndOpenIdle(page, `initial i at 1,1
+state idle "Idle" at 3,3 size 8x5 do=Poll
+state active "Active" at 14,3 size 8x5
+i -> idle`);
+    await page.evaluate(() => {
+      const el = document.getElementById('pp-do');
+      el.focus();
+      el.value = 'Poll\n-> a';
+      el.setSelectionRange(el.value.length, el.value.length);
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await page.waitForTimeout(100);
+    await page.keyboard.press('Enter');
+    const val = await page.evaluate(() => document.getElementById('pp-do').value);
+    expect(val).toContain('active');
+  });
+
+  test('editing pp-do writes back to DSL with \\n escape', async ({ page }) => {
+    await setDslAndOpenIdle(page, `initial i at 1,1
+state idle "Idle" at 3,3 size 8x5 do=Poll
+state active "Active" at 14,3 size 8x5
+i -> idle`);
+    await page.evaluate(() => {
+      const el = document.getElementById('pp-do');
+      el.value = 'CheckReady\n-> active';
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+      el.dispatchEvent(new Event('change', { bubbles: true }));
+      el.dispatchEvent(new Event('blur', { bubbles: true }));
+    });
+    await page.waitForTimeout(150);
+    const dsl = await page.evaluate(() => getDsl());
+    // Should contain do="CheckReady\n-> active" (quoted + \n escape)
+    expect(dsl).toMatch(/do="CheckReady\\n-> active"/);
+  });
+});

--- a/tests/cyclic-transitions/dsl-parser.spec.js
+++ b/tests/cyclic-transitions/dsl-parser.spec.js
@@ -14,7 +14,7 @@ async function setDslAndGetParsed(page, dsl) {
     return {
       transitions: parsed.transitions.map(t => ({
         from: t.from, to: t.to, event: t.event, guard: t.guard,
-        action: t.action, kind: t.kind, cyclic: t.cyclic === true
+        action: t.action, kind: t.kind, cyclic: t.cyclic
       })),
       errors: parsed.errors.map(e => e.msg)
     };

--- a/tests/cyclic-transitions/dsl-parser.spec.js
+++ b/tests/cyclic-transitions/dsl-parser.spec.js
@@ -1,0 +1,93 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+const BASE = 'http://localhost:8765/stablestate.html';
+
+async function setDslAndGetParsed(page, dsl) {
+  await page.evaluate((d) => {
+    const ta = document.querySelector('#editor');
+    ta.value = d;
+    ta.dispatchEvent(new Event('input', { bubbles: true }));
+  }, dsl);
+  await page.waitForTimeout(50);
+  return await page.evaluate(() => {
+    return {
+      transitions: parsed.transitions.map(t => ({
+        from: t.from, to: t.to, event: t.event, guard: t.guard,
+        action: t.action, kind: t.kind, cyclic: t.cyclic === true
+      })),
+      errors: parsed.errors.map(e => e.msg)
+    };
+  });
+}
+
+test.describe('@cyclic DSL parser', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(BASE);
+    await page.waitForFunction(() => typeof parsed !== 'undefined');
+  });
+
+  test('@cyclic alone sets cyclic=true, kind=default', async ({ page }) => {
+    const dsl = `initial i at 1,1
+state idle "Idle" at 3,3 size 8x5 do=Poll
+state active "Active" at 14,3 size 8x5
+i -> idle
+idle -> active : [Ready] / Init @cyclic`;
+    const r = await setDslAndGetParsed(page, dsl);
+    const t = r.transitions.find(x => x.from === 'idle' && x.to === 'active');
+    expect(t).toBeTruthy();
+    expect(t.cyclic).toBe(true);
+    expect(t.kind).toBe('local'); // default when @config transition not set
+    expect(t.guard).toBe('Ready');
+    expect(t.action).toBe('Init');
+  });
+
+  test('@cyclic @external combined, order 1', async ({ page }) => {
+    const dsl = `initial i at 1,1
+state a "A" at 3,3 size 8x5 do=Poll
+state b "B" at 14,3 size 8x5
+i -> a
+a -> b : EvX [G] / Act @cyclic @external`;
+    const r = await setDslAndGetParsed(page, dsl);
+    const t = r.transitions.find(x => x.from === 'a' && x.to === 'b');
+    expect(t.cyclic).toBe(true);
+    expect(t.kind).toBe('external');
+    expect(t.event).toBe('EvX');
+  });
+
+  test('@external @cyclic combined, reverse order', async ({ page }) => {
+    const dsl = `initial i at 1,1
+state a "A" at 3,3 size 8x5 do=Poll
+state b "B" at 14,3 size 8x5
+i -> a
+a -> b : EvX [G] / Act @external @cyclic`;
+    const r = await setDslAndGetParsed(page, dsl);
+    const t = r.transitions.find(x => x.from === 'a' && x.to === 'b');
+    expect(t.cyclic).toBe(true);
+    expect(t.kind).toBe('external');
+  });
+
+  test('no @cyclic → cyclic=false (backward compat)', async ({ page }) => {
+    const dsl = `initial i at 1,1
+state a "A" at 3,3 size 8x5
+state b "B" at 14,3 size 8x5
+i -> a
+a -> b : EvX`;
+    const r = await setDslAndGetParsed(page, dsl);
+    const t = r.transitions.find(x => x.from === 'a' && x.to === 'b');
+    expect(t.cyclic).toBe(false);
+  });
+
+  test('serializer: @kind @cyclic in stable order', async ({ page }) => {
+    const dsl = `initial i at 1,1
+state a "A" at 3,3 size 8x5 do=Poll
+state b "B" at 14,3 size 8x5
+i -> a`;
+    await setDslAndGetParsed(page, dsl);
+    const out = await page.evaluate(() => {
+      const newDsl = addTransition('a', 'b', 'EvX', 'G', 'Act', 'external', getDsl(), true /* cyclic */);
+      return newDsl;
+    });
+    expect(out).toMatch(/a -> b : EvX \[G\] \/ Act @external @cyclic/);
+  });
+});

--- a/tests/cyclic-transitions/export.spec.js
+++ b/tests/cyclic-transitions/export.spec.js
@@ -1,0 +1,80 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+const BASE = 'http://localhost:8765/stablestate.html';
+
+async function setDsl(page, dsl) {
+  await page.evaluate((d) => {
+    const ta = document.querySelector('#editor');
+    ta.value = d;
+    ta.dispatchEvent(new Event('input', { bubbles: true }));
+  }, dsl);
+  await page.waitForTimeout(100);
+}
+
+async function capturePlantUMLDownload(page) {
+  const [dl] = await Promise.all([
+    page.waitForEvent('download'),
+    page.evaluate(() => exportPlantUML())
+  ]);
+  const stream = await dl.createReadStream();
+  if (!stream) return null;
+  let buf = '';
+  for await (const chunk of stream) buf += chunk.toString();
+  return buf;
+}
+
+test.describe('@cyclic export', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(BASE);
+    await page.waitForFunction(() => typeof parsed !== 'undefined');
+  });
+
+  test('SVG export preserves cyclic dash and glyph', async ({ page }) => {
+    await setDsl(page, `initial i at 1,1
+state a "A" at 3,3 size 8x5 do=Poll
+state b "B" at 14,3 size 8x5
+i -> a
+a -> b : [Ready] / Init @cyclic`);
+    const svg = await page.evaluate(() => getExportSVGString());
+    expect(svg).toContain('stroke-dasharray');
+    expect(svg).toContain('⟳');
+    // Sprint 2 OBS-08 regression: resize handles still stripped
+    expect(svg).not.toContain('data-resize=');
+  });
+
+  test('SVG export keeps arr-cyclic marker', async ({ page }) => {
+    await setDsl(page, `initial i at 1,1
+state a "A" at 3,3 size 8x5 do=Poll
+state b "B" at 14,3 size 8x5
+i -> a
+a -> b : [G] @cyclic`);
+    const svg = await page.evaluate(() => getExportSVGString());
+    expect(svg).toContain('id="arr-cyclic"');
+    expect(svg).toContain('#F59E0B');
+  });
+
+  test('PlantUML export emits cyclic transition with color and dashed arrow', async ({ page }) => {
+    await setDsl(page, `initial i at 1,1
+state a "A" at 3,3 size 8x5 do=Poll
+state b "B" at 14,3 size 8x5
+i -> a
+a -> b : [Ready] / Init @cyclic`);
+    const puml = await capturePlantUMLDownload(page);
+    expect(puml).not.toBeNull();
+    expect(puml).toMatch(/a\s+-\[#F59E0B,dashed\]->\s+b/);
+    expect(puml).toContain('⟳');
+  });
+
+  test('PlantUML non-cyclic unchanged', async ({ page }) => {
+    await setDsl(page, `initial i at 1,1
+state a "A" at 3,3 size 8x5
+state b "B" at 14,3 size 8x5
+i -> a
+a -> b : EvX`);
+    const puml = await capturePlantUMLDownload(page);
+    expect(puml).not.toContain('#F59E0B');
+    expect(puml).not.toContain('⟳');
+    expect(puml).toMatch(/a\s+-->\s+b/);
+  });
+});

--- a/tests/cyclic-transitions/export.spec.js
+++ b/tests/cyclic-transitions/export.spec.js
@@ -78,3 +78,51 @@ a -> b : EvX`);
     expect(puml).toMatch(/a\s+-->\s+b/);
   });
 });
+
+test.describe('@cyclic export — multiline do in PlantUML', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(BASE);
+    await page.waitForFunction(() => typeof parsed !== 'undefined');
+  });
+
+  async function captureDl(page, fn) {
+    const [dl] = await Promise.all([
+      page.waitForEvent('download'),
+      page.evaluate(fn)
+    ]);
+    const stream = await dl.createReadStream();
+    if (!stream) return null;
+    let buf = '';
+    for await (const chunk of stream) buf += chunk.toString();
+    return buf;
+  }
+
+  async function setDsl(page, dsl) {
+    await page.evaluate((d) => {
+      const ta = document.querySelector('#editor');
+      ta.value = d;
+      ta.dispatchEvent(new Event('input', { bubbles: true }));
+    }, dsl);
+    await page.waitForTimeout(100);
+  }
+
+  test('single-line do emitted as state description', async ({ page }) => {
+    await setDsl(page, `initial i at 1,1
+state idle "Idle" at 3,3 size 8x5 do=PollReady
+i -> idle`);
+    const puml = await captureDl(page, () => exportPlantUML());
+    expect(puml).not.toBeNull();
+    expect(puml).toMatch(/idle\s*:\s*do\s*\/\s*PollReady/);
+  });
+
+  test('multiline do encoded as \\n literal in PlantUML', async ({ page }) => {
+    await setDsl(page, `initial i at 1,1
+state idle "Idle" at 3,3 size 8x5 do="Check1\\nCheck2\\n-> active"
+state active "Active" at 14,3 size 8x5
+i -> idle`);
+    const puml = await captureDl(page, () => exportPlantUML());
+    expect(puml).not.toBeNull();
+    // The 2-char \n literal survives to PlantUML as-is — PlantUML interprets \n as line break
+    expect(puml).toMatch(/idle\s*:\s*do\s*\/\s*Check1\\nCheck2\\n-> active/);
+  });
+});

--- a/tests/cyclic-transitions/export.spec.js
+++ b/tests/cyclic-transitions/export.spec.js
@@ -12,10 +12,15 @@ async function setDsl(page, dsl) {
   await page.waitForTimeout(100);
 }
 
-async function capturePlantUMLDownload(page) {
+// Generic download capture: trigger `fn` inside the page, wait for the
+// download event, read the resulting stream as text. Used by both the
+// PlantUML export tests below and the multiline-do describe block that
+// follows — previously each block had its own duplicate copy of this
+// helper (Task 11 code review M2 polish).
+async function captureDl(page, fn) {
   const [dl] = await Promise.all([
     page.waitForEvent('download'),
-    page.evaluate(() => exportPlantUML())
+    page.evaluate(fn)
   ]);
   const stream = await dl.createReadStream();
   if (!stream) return null;
@@ -60,7 +65,7 @@ state a "A" at 3,3 size 8x5 do=Poll
 state b "B" at 14,3 size 8x5
 i -> a
 a -> b : [Ready] / Init @cyclic`);
-    const puml = await capturePlantUMLDownload(page);
+    const puml = await captureDl(page, () => exportPlantUML());
     expect(puml).not.toBeNull();
     expect(puml).toMatch(/a\s+-\[#F59E0B,dashed\]->\s+b/);
     expect(puml).toContain('⟳');
@@ -72,7 +77,7 @@ state a "A" at 3,3 size 8x5
 state b "B" at 14,3 size 8x5
 i -> a
 a -> b : EvX`);
-    const puml = await capturePlantUMLDownload(page);
+    const puml = await captureDl(page, () => exportPlantUML());
     expect(puml).not.toContain('#F59E0B');
     expect(puml).not.toContain('⟳');
     expect(puml).toMatch(/a\s+-->\s+b/);
@@ -84,27 +89,6 @@ test.describe('@cyclic export — multiline do in PlantUML', () => {
     await page.goto(BASE);
     await page.waitForFunction(() => typeof parsed !== 'undefined');
   });
-
-  async function captureDl(page, fn) {
-    const [dl] = await Promise.all([
-      page.waitForEvent('download'),
-      page.evaluate(fn)
-    ]);
-    const stream = await dl.createReadStream();
-    if (!stream) return null;
-    let buf = '';
-    for await (const chunk of stream) buf += chunk.toString();
-    return buf;
-  }
-
-  async function setDsl(page, dsl) {
-    await page.evaluate((d) => {
-      const ta = document.querySelector('#editor');
-      ta.value = d;
-      ta.dispatchEvent(new Event('input', { bubbles: true }));
-    }, dsl);
-    await page.waitForTimeout(100);
-  }
 
   test('single-line do emitted as state description', async ({ page }) => {
     await setDsl(page, `initial i at 1,1

--- a/tests/cyclic-transitions/property-panel.spec.js
+++ b/tests/cyclic-transitions/property-panel.spec.js
@@ -1,0 +1,92 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+const BASE = 'http://localhost:8765/stablestate.html';
+
+async function setDsl(page, dsl) {
+  await page.evaluate((d) => {
+    const ta = document.querySelector('#editor');
+    ta.value = d;
+    ta.dispatchEvent(new Event('input', { bubbles: true }));
+  }, dsl);
+  await page.waitForTimeout(100);
+}
+
+async function switchToTable(page) {
+  await page.evaluate(() => {
+    const tabs = Array.from(document.querySelectorAll('.tab-btn'));
+    const t = tabs.find(b => /table|テーブル/i.test(b.textContent || ''));
+    if (t) t.click();
+  });
+  await page.waitForTimeout(100);
+}
+
+async function clickActionCell(page, actionText) {
+  await page.evaluate((needle) => {
+    const td = Array.from(document.querySelectorAll('#table-wrap td[data-field="action"]'))
+      .find(c => (c.textContent || '').includes(needle));
+    if (td) td.click();
+  }, actionText);
+  await page.waitForTimeout(100);
+}
+
+test.describe('@cyclic property panel', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(BASE);
+    await page.waitForFunction(() => typeof parsed !== 'undefined');
+  });
+
+  test('checkbox exists when opening a transition cell', async ({ page }) => {
+    await setDsl(page, `initial i at 1,1
+state a "A" at 3,3 size 8x5 do=Poll
+state b "B" at 14,3 size 8x5
+i -> a
+a -> b : EvX [G] / Act`);
+    await switchToTable(page);
+    await clickActionCell(page, 'Act');
+    const exists = await page.evaluate(() => !!document.getElementById('pp-table-cyclic'));
+    expect(exists).toBe(true);
+  });
+
+  test('ON checkbox adds @cyclic to DSL, preserving indent (OBS-13)', async ({ page }) => {
+    await setDsl(page, `initial i at 1,1
+state parent "Parent" at 3,3 size 24x14 {
+  state a "A" at 3,3 size 8x5 do=Poll
+  state b "B" at 14,3 size 8x5
+  a -> b : EvX [G] / Act
+}
+i -> parent`);
+    await switchToTable(page);
+    await clickActionCell(page, 'Act');
+    await page.evaluate(() => {
+      const cb = document.getElementById('pp-table-cyclic');
+      cb.checked = true;
+      cb.dispatchEvent(new Event('change', { bubbles: true }));
+      document.getElementById('pp-table-apply').click();
+    });
+    await page.waitForTimeout(100);
+    const dsl = await page.evaluate(() => getDsl());
+    // Line should retain 2-space indent and bare IDs, gain @cyclic suffix
+    expect(dsl).toContain('  a -> b : EvX [G] / Act @cyclic');
+  });
+
+  test('OFF checkbox removes @cyclic from DSL', async ({ page }) => {
+    await setDsl(page, `initial i at 1,1
+state a "A" at 3,3 size 8x5 do=Poll
+state b "B" at 14,3 size 8x5
+i -> a
+a -> b : EvX [G] / Act @cyclic`);
+    await switchToTable(page);
+    await clickActionCell(page, 'Act');
+    await page.evaluate(() => {
+      const cb = document.getElementById('pp-table-cyclic');
+      cb.checked = false;
+      cb.dispatchEvent(new Event('change', { bubbles: true }));
+      document.getElementById('pp-table-apply').click();
+    });
+    await page.waitForTimeout(100);
+    const dsl = await page.evaluate(() => getDsl());
+    expect(dsl).not.toContain('@cyclic');
+    expect(dsl).toContain('a -> b : EvX [G] / Act');
+  });
+});

--- a/tests/cyclic-transitions/regression.spec.js
+++ b/tests/cyclic-transitions/regression.spec.js
@@ -1,0 +1,382 @@
+// @ts-check
+// Cross-feature regression sweep (Task 12 of @cyclic transitions plan).
+//
+// This file locks in the 10 OBS fixes delivered by Sprint 1-6 plus the
+// 2026-04-04 action-textarea autocomplete feature. Every test here re-
+// exercises an existing behavior end-to-end via the running dev server
+// and asserts the fixed invariant. If any of these ever start failing we
+// know a cross-feature change broke a previously-shipped safety net.
+//
+// Design notes:
+//   - Helpers at the top (loadExample / setDsl / switchToTable / captureDl)
+//     keep each test body short and declarative.
+//   - `parsed` and `sel` are script-scoped `let` bindings inside
+//     stablestate.html, so they are reached via `eval('parsed')` /
+//     `eval('sel = [...]')` inside page.evaluate — same pattern as the
+//     Sprint 1-6 specs in tests/ux-brushup.
+//   - Top-level `function` declarations in stablestate.html (setDsl,
+//     refresh, getDsl, autoRoute, addNewElement, deleteSelected,
+//     updateTransFieldByLine, exportPlantUML, getExportSVGString,
+//     switchTab, ...) ARE available as `window.<name>`.
+
+const { test, expect } = require('@playwright/test');
+
+const BASE = 'http://localhost:8765/stablestate.html';
+
+// Fetch one of the examples/*.sstate files via the dev server and install
+// it into the editor textarea, triggering the input handler so the app
+// runs its full refresh() pipeline (parse → cleanupInternalTransitions →
+// renderSVG → renderTable).
+async function loadExample(page, filename) {
+  await page.evaluate(async (name) => {
+    const res = await fetch('examples/' + name);
+    const text = await res.text();
+    const ta = document.querySelector('#editor');
+    ta.value = text;
+    ta.dispatchEvent(new Event('input', { bubbles: true }));
+  }, filename);
+  await page.waitForTimeout(200);
+}
+
+// Seed the editor with an inline DSL string and fire the input handler.
+async function setDsl(page, dsl) {
+  await page.evaluate((d) => {
+    const ta = document.querySelector('#editor');
+    ta.value = d;
+    ta.dispatchEvent(new Event('input', { bubbles: true }));
+  }, dsl);
+  await page.waitForTimeout(100);
+}
+
+// Switch to the Table tab via the global switchTab function (the click
+// handler on the toolbar button calls exactly this).
+async function switchToTable(page) {
+  await page.evaluate(() => {
+    if (typeof switchTab === 'function') switchTab('table');
+  });
+  await page.waitForTimeout(100);
+}
+
+// Trigger a download by invoking `fn` inside the page, wait for the
+// download event, read the stream and return its text. Works because
+// exportPlantUML() uses anchor.click() → the browser fires a download.
+async function captureDl(page, fn) {
+  const [dl] = await Promise.all([
+    page.waitForEvent('download'),
+    page.evaluate(fn)
+  ]);
+  const stream = await dl.createReadStream();
+  if (!stream) return null;
+  let buf = '';
+  for await (const chunk of stream) buf += chunk.toString();
+  return buf;
+}
+
+test.describe('Cross-feature regression sweep', () => {
+  test.beforeEach(async ({ page }) => {
+    // Silence any confirm() dialogs the app may raise during batch edits.
+    page.on('dialog', d => d.dismiss().catch(() => {}));
+    await page.goto(BASE);
+    await page.waitForFunction(() =>
+      typeof window.setDsl === 'function' &&
+      typeof window.refresh === 'function' &&
+      typeof parsed !== 'undefined'
+    );
+  });
+
+  // ─── Sprint 1 ─────────────────────────────────────────────────────────
+  test('OBS-04: AutoRoute does not throw ReferenceError', async ({ page }) => {
+    const pageErrors = [];
+    const consoleErrors = [];
+    page.on('pageerror', e => pageErrors.push(e.message));
+    page.on('console', m => { if (m.type() === 'error') consoleErrors.push(m.text()); });
+
+    await loadExample(page, 'tcp-connection.sstate');
+
+    const result = await page.evaluate(() => {
+      try {
+        if (typeof window.autoRoute === 'function') window.autoRoute();
+        return { ok: true };
+      } catch (e) {
+        return { ok: false, error: String(e) + '\n' + (e.stack || '') };
+      }
+    });
+
+    expect(result.ok, `autoRoute() threw: ${result.error || ''}`).toBe(true);
+    const combined = pageErrors.join('\n') + '\n' + consoleErrors.join('\n');
+    expect(combined).not.toMatch(/ReferenceError/);
+    expect(combined).not.toMatch(/getBox is not defined/);
+  });
+
+  test('OBS-13: Table guard edit preserves indent and bare ids on nested transitions', async ({ page }) => {
+    await loadExample(page, 'automotive-ecu.sstate');
+
+    // updateTransFieldByLine is the Sprint 1 OBS-13 preservation path.
+    // It mutates the editor in place (setDsl + refresh) — we read getDsl()
+    // AFTER the call to see the result.
+    const result = await page.evaluate(() => {
+      if (typeof window.updateTransFieldByLine !== 'function') {
+        return { ok: false, reason: 'updateTransFieldByLine missing' };
+      }
+      const dsl = window.getDsl();
+      const lines = dsl.split('\n');
+      // Locate `    idle -> active : EvDriveRequest [IsReady] / InitDrive`
+      let lineIdx = -1;
+      for (let i = 0; i < lines.length; i++) {
+        if (/^\s+idle\s*->\s*active\s*:\s*EvDriveRequest\s*\[IsReady\]/.test(lines[i])) {
+          lineIdx = i;
+          break;
+        }
+      }
+      if (lineIdx < 0) return { ok: false, reason: 'target line not found' };
+
+      window.updateTransFieldByLine(lineIdx + 1, 'guard', 'IsReady && BatteryOK');
+      const newDsl = window.getDsl();
+      const newLine = newDsl.split('\n')[lineIdx];
+      return { ok: true, newLine, newDsl };
+    });
+
+    expect(result.ok, `OBS-13 setup failed: ${result.reason || ''}`).toBe(true);
+    // Indentation preserved (at least 4 spaces).
+    expect(result.newLine).toMatch(/^\s{4}idle\s*->\s*active/);
+    // New guard applied.
+    expect(result.newLine).toContain('[IsReady && BatteryOK]');
+    // Bare ids kept — no dotted-path corruption.
+    expect(result.newLine).not.toContain('run.normal.idle');
+    expect(result.newDsl).not.toMatch(/run\.normal\.idle\s*->\s*run\.normal\.active/);
+  });
+
+  // ─── Sprint 2 ─────────────────────────────────────────────────────────
+  test('OBS-08: SVG export strips data-resize handles', async ({ page }) => {
+    await loadExample(page, 'automotive-ecu.sstate');
+    const svg = await page.evaluate(() => getExportSVGString());
+    expect(svg).toBeTruthy();
+    expect(svg).not.toContain('data-resize=');
+  });
+
+  test('OBS-11: PlantUML export nests history and declares final as <<end>>', async ({ page }) => {
+    await loadExample(page, 'automotive-ecu.sstate');
+    const puml = await captureDl(page, () => exportPlantUML());
+    expect(puml).not.toBeNull();
+    // history pseudo-state declared with <<history>>
+    expect(puml).toMatch(/state\s+h_run\s+<<history>>/);
+    // final pseudo-state declared with <<end>> (not flattened to [*])
+    expect(puml).toMatch(/state\s+shutdown\s+<<end>>/);
+  });
+
+  // ─── Sprint 3 ─────────────────────────────────────────────────────────
+  test('OBS-02: Unrecognized syntax error includes template hint', async ({ page }) => {
+    await setDsl(page, 'state Red');
+
+    const errMsgs = await page.evaluate(() => {
+      // eslint-disable-next-line no-eval
+      const p = eval('parsed');
+      return p && p.errors ? p.errors.map(e => e.msg || String(e)) : [];
+    });
+
+    expect(errMsgs.length).toBeGreaterThan(0);
+    const joined = errMsgs.join('\n');
+    expect(joined).toContain('Unrecognized syntax');
+    // Template fragments appended by the Sprint 3 fix — plain substring
+    // checks (the raw errors[] strings carry the literal <id>/<label>
+    // placeholders before HTML escaping).
+    expect(joined).toContain('expected: state <id>');
+    expect(joined).toContain('"<label>"');
+    expect(joined).toContain('at <x>,<y>');
+    expect(joined).toContain('size <w>x<h>');
+  });
+
+  test('OBS-16: Brace mismatch hint survives (Sprint 3 base family)', async ({ page }) => {
+    await loadExample(page, 'automotive-ecu.sstate');
+
+    const errMsgs = await page.evaluate(() => {
+      const dsl = window.getDsl();
+      // Strip the trailing `{` from the `state run "Run" ...` line.
+      const broken = dsl.split('\n').map(l =>
+        /^state\s+run\s+"Run"\s+.*\{\s*$/.test(l) ? l.replace(/\s*\{\s*$/, '') : l
+      ).join('\n');
+      window.setDsl(broken);
+      window.refresh();
+      // eslint-disable-next-line no-eval
+      const p = eval('parsed');
+      return p && p.errors ? p.errors.map(e => 'L' + e.line + ': ' + e.msg) : [];
+    });
+
+    expect(errMsgs.length).toBeGreaterThan(0);
+    const joined = errMsgs.join('\n');
+    // At least one of the Sprint 3 hint families must be present.
+    expect(joined).toMatch(/Unclosed '\{'|no matching|Hint:|Unexpected closing brace/);
+  });
+
+  // ─── Sprint 4 ─────────────────────────────────────────────────────────
+  test('OBS-15: Deleting cruise removes its orphan transitions', async ({ page }) => {
+    await loadExample(page, 'automotive-ecu.sstate');
+
+    const result = await page.evaluate(() => {
+      // eslint-disable-next-line no-eval
+      const p = eval('parsed');
+      const cruiseEl = p && p.stateMap ? p.stateMap['cruise'] : null;
+      const cruisePath = cruiseEl ? (cruiseEl.path || cruiseEl.id || 'cruise') : 'cruise';
+      // Select cruise the way a click does (path-based id) and delete it.
+      // eslint-disable-next-line no-eval
+      eval('sel = [{type: "state", id: ' + JSON.stringify(cruisePath) + '}]');
+      window.deleteSelected();
+      return { dsl: window.getDsl() };
+    });
+
+    // After deletion, no transitions should reference cruise as endpoint.
+    expect(result.dsl).not.toMatch(/accel\s*->\s*cruise/);
+    expect(result.dsl).not.toMatch(/cruise\s*->\s*accel/);
+    // And the state definition itself must be gone.
+    expect(result.dsl).not.toMatch(/state\s+cruise\b/);
+  });
+
+  test('OBS-01: +State button yields distinct root coordinates across consecutive calls', async ({ page }) => {
+    // Start with a minimal canvas so addNewElement's root slot search has
+    // a predictable sizing frame. Empty DSL also works, but this is more
+    // explicit about the test setup.
+    await setDsl(page, '@canvas width=800 height=600 grid=20\n');
+
+    const coords = await page.evaluate(() => {
+      // Ensure no state is selected — OBS-01 is specifically the root-add
+      // path (parentState === null branch of addNewElement).
+      // eslint-disable-next-line no-eval
+      eval('sel = []');
+      const xs = [];
+      for (let i = 0; i < 3; i++) {
+        if (typeof window.addNewElement === 'function') window.addNewElement('state');
+      }
+      const dsl = window.getDsl();
+      const re = /at\s+(\d+(?:\.\d+)?),(\d+(?:\.\d+)?)/g;
+      let m;
+      while ((m = re.exec(dsl)) !== null) {
+        xs.push(m[1] + ',' + m[2]);
+      }
+      return xs;
+    });
+
+    expect(coords.length).toBeGreaterThanOrEqual(3);
+    const unique = new Set(coords);
+    expect(
+      unique.size,
+      `Expected at least as many unique coords as calls, got ${coords.length} coords with ${unique.size} unique: ${JSON.stringify(coords)}`
+    ).toBe(coords.length);
+  });
+
+  // ─── Sprint 5 ─────────────────────────────────────────────────────────
+  test('OBS-19: @internal self-transition with a trigger survives load', async ({ page }) => {
+    await loadExample(page, 'automotive-ecu.sstate');
+
+    const result = await page.evaluate(() => {
+      const dsl = window.getDsl();
+      // eslint-disable-next-line no-eval
+      const p = eval('parsed');
+      const watchdog = (p && p.transitions ? p.transitions : [])
+        .filter(t => t.from === 'run' && t.to === 'run' && t.kind === 'internal' && t.event === 'EvWatchdogKick');
+      return { dsl, watchdogCount: watchdog.length };
+    });
+
+    // DSL text itself preserves the line.
+    expect(result.dsl).toContain('run -> run : EvWatchdogKick @internal');
+    // Runtime representation carries it too.
+    expect(result.watchdogCount).toBeGreaterThanOrEqual(1);
+  });
+
+  // ─── Sprint 6 ─────────────────────────────────────────────────────────
+  test('OBS-18: Brace hint anchors at the true unclosed frame (run, not failsafe)', async ({ page }) => {
+    await loadExample(page, 'automotive-ecu.sstate');
+
+    const out = await page.evaluate(() => {
+      const dsl = window.getDsl();
+      // Find `run` composite line and strip its trailing `{`.
+      const lines = dsl.split('\n');
+      let runLine = -1;
+      for (let i = 0; i < lines.length; i++) {
+        if (/^state\s+run\s+"Run"\s+.*\{\s*$/.test(lines[i])) {
+          runLine = i + 1; // 1-based
+          lines[i] = lines[i].replace(/\s*\{\s*$/, '');
+          break;
+        }
+      }
+      window.setDsl(lines.join('\n'));
+      window.refresh();
+      // eslint-disable-next-line no-eval
+      const p = eval('parsed');
+      return {
+        runLine,
+        errorMsgs: p && p.errors ? p.errors.map(e => 'L' + e.line + ': ' + e.msg) : []
+      };
+    });
+
+    expect(out.runLine).toBeGreaterThan(0);
+    expect(out.errorMsgs.length).toBeGreaterThan(0);
+
+    const joined = out.errorMsgs.join('\n');
+    // Hint-bearing families from Sprint 3/6.
+    const hintBearing = out.errorMsgs.filter(m =>
+      m.includes('Hint:') || m.includes("Unclosed '{'")
+    );
+    expect(hintBearing.length, `expected at least one Hint/Unclosed message in:\n${joined}`).toBeGreaterThan(0);
+
+    // The hint must reference `run` (as a word) or L<runLine>. Sprint 6
+    // fixed this from previously misdirecting to `failsafe`/L49.
+    const runToken = 'L' + out.runLine;
+    const mentionsRun = hintBearing.some(m => /\brun\b/.test(m) || m.includes(runToken));
+    expect(
+      mentionsRun,
+      `OBS-18: hint must reference 'run' or ${runToken}, got:\n${hintBearing.join('\n')}`
+    ).toBe(true);
+  });
+
+  // ─── Action autocomplete (2026-04-04 feature) ─────────────────────────
+  test('Action textarea autocomplete still works after Task 8 helper extraction', async ({ page }) => {
+    await setDsl(page, `initial i at 1,1
+state a "A" at 3,3 size 8x5
+state b "B" at 14,3 size 8x5
+i -> a
+a -> b : EvX / Act`);
+
+    await switchToTable(page);
+
+    // Click the action cell for the a->b transition. The cell has
+    // data-field="action" and its textContent starts with `Act`.
+    const clicked = await page.evaluate(() => {
+      const tds = Array.from(document.querySelectorAll('#table-wrap td[data-field="action"]'));
+      const target = tds.find(c => (c.textContent || '').trim().startsWith('Act'));
+      if (target) { target.click(); return true; }
+      return false;
+    });
+    expect(clicked, 'action cell with text Act should exist in the table view').toBe(true);
+
+    // Property panel must have rendered a <textarea id="pp-table-action">.
+    // The Task 8 extraction promoted this editor from <input> to <textarea>.
+    const taTag = await page.evaluate(() => {
+      const el = document.getElementById('pp-table-action');
+      return el ? el.tagName : null;
+    });
+    expect(taTag).toBe('TEXTAREA');
+
+    // Type `-> b` into the textarea. attachMultilineAutocomplete (Task 8)
+    // should detect the `-> ` prefix, invoke stateCandidates(), filter by
+    // `b`, and show a single `.ac-item` for state `b`.
+    await page.evaluate(() => {
+      const el = document.getElementById('pp-table-action');
+      el.focus();
+      el.value = '-> b';
+      el.setSelectionRange(el.value.length, el.value.length);
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await page.waitForTimeout(100);
+
+    const acInfo = await page.evaluate(() => {
+      const list = document.querySelector('.ac-list');
+      if (!list) return { present: false, count: 0, items: [] };
+      const items = Array.from(list.querySelectorAll('.ac-item')).map(el => (el.textContent || '').trim());
+      return { present: true, count: items.length, items };
+    });
+
+    expect(acInfo.present, 'autocomplete .ac-list should appear after typing `-> b`').toBe(true);
+    expect(acInfo.count).toBeGreaterThanOrEqual(1);
+    expect(acInfo.items).toContain('b');
+  });
+});

--- a/tests/cyclic-transitions/rendering.spec.js
+++ b/tests/cyclic-transitions/rendering.spec.js
@@ -1,0 +1,104 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+const BASE = 'http://localhost:8765/stablestate.html';
+
+async function setDsl(page, dsl) {
+  await page.evaluate((d) => {
+    const ta = document.querySelector('#editor');
+    ta.value = d;
+    ta.dispatchEvent(new Event('input', { bubbles: true }));
+  }, dsl);
+  await page.waitForTimeout(100);
+}
+
+test.describe('@cyclic renderSVG', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(BASE);
+    await page.waitForFunction(() => typeof parsed !== 'undefined');
+  });
+
+  test('cyclic transition has stroke-dasharray 6,4 and amber stroke', async ({ page }) => {
+    await setDsl(page, `initial i at 1,1
+state a "A" at 3,3 size 8x5 do=Poll
+state b "B" at 14,3 size 8x5
+i -> a
+a -> b : [G] / Act @cyclic`);
+    const info = await page.evaluate(() => {
+      const paths = Array.from(document.querySelectorAll('#svg-wrap svg polyline, #svg-wrap svg path'));
+      return paths.map(p => ({
+        tag: p.tagName,
+        dash: p.getAttribute('stroke-dasharray'),
+        stroke: p.getAttribute('stroke')
+      }));
+    });
+    const cyclicEdge = info.find(p => p.stroke && p.stroke.toLowerCase() === '#f59e0b');
+    expect(cyclicEdge).toBeTruthy();
+    expect(cyclicEdge.dash).toBe('6,4');
+  });
+
+  test('cyclic label has ⟳ prefix', async ({ page }) => {
+    await setDsl(page, `initial i at 1,1
+state a "A" at 3,3 size 8x5 do=Poll
+state b "B" at 14,3 size 8x5
+i -> a
+a -> b : [Ready] / InitDrive @cyclic`);
+    const labelText = await page.evaluate(() => {
+      const texts = Array.from(document.querySelectorAll('#svg-wrap svg text'));
+      return texts.map(t => t.textContent).join(' | ');
+    });
+    expect(labelText).toContain('⟳');
+  });
+
+  test('user color override wins, ⟳ still shown', async ({ page }) => {
+    await setDsl(page, `initial i at 1,1
+state a "A" at 3,3 size 8x5 do=Poll
+state b "B" at 14,3 size 8x5
+i -> a
+a -> b : [G] / Act @cyclic color=#0000FF`);
+    const info = await page.evaluate(() => {
+      const paths = Array.from(document.querySelectorAll('#svg-wrap svg polyline, #svg-wrap svg path'));
+      const texts = Array.from(document.querySelectorAll('#svg-wrap svg text')).map(t => t.textContent).join(' | ');
+      return {
+        paths: paths.map(p => ({ dash: p.getAttribute('stroke-dasharray'), stroke: p.getAttribute('stroke') })),
+        hasCycleGlyph: texts.includes('⟳')
+      };
+    });
+    const userColored = info.paths.find(p => p.stroke && p.stroke.toLowerCase() === '#0000ff');
+    expect(userColored).toBeTruthy();
+    expect(info.hasCycleGlyph).toBe(true);
+  });
+
+  test('user style=solid override removes dash, ⟳ still shown', async ({ page }) => {
+    await setDsl(page, `initial i at 1,1
+state a "A" at 3,3 size 8x5 do=Poll
+state b "B" at 14,3 size 8x5
+i -> a
+a -> b : [G] / Act @cyclic style=solid`);
+    const info = await page.evaluate(() => {
+      const paths = Array.from(document.querySelectorAll('#svg-wrap svg polyline, #svg-wrap svg path'));
+      const texts = Array.from(document.querySelectorAll('#svg-wrap svg text')).map(t => t.textContent).join(' | ');
+      return {
+        paths: paths.map(p => ({ dash: p.getAttribute('stroke-dasharray'), stroke: p.getAttribute('stroke') })),
+        hasCycleGlyph: texts.includes('⟳')
+      };
+    });
+    const amberPath = info.paths.find(p => p.stroke && p.stroke.toLowerCase() === '#f59e0b');
+    expect(amberPath).toBeTruthy();
+    expect(amberPath.dash).toBeFalsy();
+    expect(info.hasCycleGlyph).toBe(true);
+  });
+
+  test('non-cyclic transitions unchanged', async ({ page }) => {
+    await setDsl(page, `initial i at 1,1
+state a "A" at 3,3 size 8x5
+state b "B" at 14,3 size 8x5
+i -> a
+a -> b : EvX`);
+    const info = await page.evaluate(() => {
+      const texts = Array.from(document.querySelectorAll('#svg-wrap svg text')).map(t => t.textContent).join(' | ');
+      return { hasCycleGlyph: texts.includes('⟳') };
+    });
+    expect(info.hasCycleGlyph).toBe(false);
+  });
+});

--- a/tests/cyclic-transitions/table-view.spec.js
+++ b/tests/cyclic-transitions/table-view.spec.js
@@ -1,0 +1,80 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+const BASE = 'http://localhost:8765/stablestate.html';
+
+async function setDsl(page, dsl) {
+  await page.evaluate((d) => {
+    const ta = document.querySelector('#editor');
+    ta.value = d;
+    ta.dispatchEvent(new Event('input', { bubbles: true }));
+  }, dsl);
+  await page.waitForTimeout(100);
+}
+
+async function switchToTable(page) {
+  await page.evaluate(() => {
+    const tabs = Array.from(document.querySelectorAll('.tab-btn'));
+    const t = tabs.find(b => /table|テーブル/i.test(b.textContent || ''));
+    if (t) t.click();
+  });
+  await page.waitForTimeout(100);
+}
+
+test.describe('@cyclic table view', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(BASE);
+    await page.waitForFunction(() => typeof parsed !== 'undefined');
+  });
+
+  test('cyclic transition cell has ⟳ prefix and amber color', async ({ page }) => {
+    await setDsl(page, `initial i at 1,1
+state idle "Idle" at 3,3 size 8x5 do=Poll
+state active "Active" at 14,3 size 8x5
+i -> idle
+idle -> active : EvReady [Ready] / Init @cyclic`);
+    await switchToTable(page);
+    const cells = await page.evaluate(() => {
+      const tds = Array.from(document.querySelectorAll('#table-wrap td'));
+      return tds
+        .filter(td => (td.textContent || '').includes('⟳'))
+        .map(td => ({
+          text: td.textContent || '',
+          color: td.style.color || td.getAttribute('style') || ''
+        }));
+    });
+    expect(cells.length).toBeGreaterThanOrEqual(1);
+    expect(cells[0].text).toMatch(/⟳/);
+    expect(cells[0].color.toLowerCase()).toMatch(/#f59e0b|rgb\(\s*245\s*,\s*158\s*,\s*11\s*\)/);
+  });
+
+  test('non-cyclic transition cell has no ⟳', async ({ page }) => {
+    await setDsl(page, `initial i at 1,1
+state a "A" at 3,3 size 8x5
+state b "B" at 14,3 size 8x5
+i -> a
+a -> b : EvX`);
+    await switchToTable(page);
+    const hasGlyph = await page.evaluate(() => {
+      return Array.from(document.querySelectorAll('#table-wrap td'))
+        .some(td => (td.textContent || '').includes('⟳'));
+    });
+    expect(hasGlyph).toBe(false);
+  });
+
+  test('cyclic + guard + action all rendered with ⟳', async ({ page }) => {
+    await setDsl(page, `initial i at 1,1
+state a "A" at 3,3 size 8x5 do=Poll
+state b "B" at 14,3 size 8x5
+i -> a
+a -> b : EvX [Ready] / Init @cyclic`);
+    await switchToTable(page);
+    const text = await page.evaluate(() => {
+      return Array.from(document.querySelectorAll('#table-wrap td'))
+        .map(td => td.textContent || '').join(' ');
+    });
+    expect(text).toContain('⟳');
+    expect(text).toContain('Ready');
+    expect(text).toContain('Init');
+  });
+});

--- a/tests/cyclic-transitions/validation.spec.js
+++ b/tests/cyclic-transitions/validation.spec.js
@@ -1,0 +1,84 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+const BASE = 'http://localhost:8765/stablestate.html';
+
+async function setDslAndGetValidation(page, dsl) {
+  await page.evaluate((d) => {
+    const ta = document.querySelector('#editor');
+    ta.value = d;
+    ta.dispatchEvent(new Event('input', { bubbles: true }));
+  }, dsl);
+  await page.waitForTimeout(100);
+  return await page.evaluate(() => ({
+    errors: (parsed.errors || []).map(e => e.msg || e),
+    warnings: (parsed.warnings || []).map(w => w.msg || w)
+  }));
+}
+
+test.describe('@cyclic validation', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(BASE);
+    await page.waitForFunction(() => typeof parsed !== 'undefined');
+  });
+
+  test('E1: initial → @cyclic raises error', async ({ page }) => {
+    const r = await setDslAndGetValidation(page, `initial i at 1,1
+state a "A" at 3,3 size 8x5
+i -> a : @cyclic`);
+    const matched = r.errors.find(m => /initial.*must not have @cyclic/i.test(m));
+    expect(matched).toBeTruthy();
+  });
+
+  test('E2: choice → @cyclic raises error', async ({ page }) => {
+    const r = await setDslAndGetValidation(page, `initial i at 1,1
+state a "A" at 3,3 size 8x5 do=Poll
+state b "B" at 14,3 size 8x5
+choice c at 10,1
+i -> a
+a -> c
+c -> b : [OK] @cyclic`);
+    const matched = r.errors.find(m => /choice.*must not have @cyclic/i.test(m));
+    expect(matched).toBeTruthy();
+  });
+
+  test('W1: cyclic transition without do= raises warning (not error)', async ({ page }) => {
+    const r = await setDslAndGetValidation(page, `initial i at 1,1
+state idle "Idle" at 3,3 size 8x5
+state active "Active" at 14,3 size 8x5
+i -> idle
+idle -> active : [Ready] @cyclic`);
+    // Should NOT be in errors
+    expect(r.errors.filter(m => /no do/i.test(m)).length).toBe(0);
+    // SHOULD be in warnings
+    expect(r.warnings.find(m => /@cyclic.*no 'do=' activity|@cyclic.*no do activity/i.test(m))).toBeTruthy();
+  });
+
+  test('cyclic with do= has no warning', async ({ page }) => {
+    const r = await setDslAndGetValidation(page, `initial i at 1,1
+state idle "Idle" at 3,3 size 8x5 do=Poll
+state active "Active" at 14,3 size 8x5
+i -> idle
+idle -> active : [Ready] @cyclic`);
+    expect(r.warnings.filter(w => /@cyclic/.test(w)).length).toBe(0);
+  });
+
+  test('event + cyclic is allowed (no warning/error)', async ({ page }) => {
+    const r = await setDslAndGetValidation(page, `initial i at 1,1
+state a "A" at 3,3 size 8x5 do=Poll
+state b "B" at 14,3 size 8x5
+i -> a
+a -> b : EvX [G] / Act @cyclic`);
+    expect(r.errors.filter(m => /@cyclic/.test(m)).length).toBe(0);
+    expect(r.warnings.filter(w => /@cyclic/.test(w) && !/do/.test(w)).length).toBe(0);
+  });
+
+  test('@external @cyclic combined is allowed', async ({ page }) => {
+    const r = await setDslAndGetValidation(page, `initial i at 1,1
+state a "A" at 3,3 size 8x5 do=Poll
+state b "B" at 14,3 size 8x5
+i -> a
+a -> b : [G] / Act @external @cyclic`);
+    expect(r.errors.filter(m => /@cyclic|@external/.test(m)).length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

AUTOSAR の cyclic runnable パターン (周期評価で自己判断する状態遷移) を DSL + 視覚表現 + 編集体験の3層で表現可能にする2機能を追加。

- **Feature 1 (cyclic 遷移)**: `@cyclic` サフィックスで遷移を宣言、破線 amber + ⟳ グリフで外部イベント遷移と視覚区別。`@kind` (local/external/internal) と直交。
- **Feature 2 (do 拡張)**: `do=` に `do="multi\nline"` クォート形式対応。プロパティパネルの `pp-do` を単一行 `<input>` から複数行 `<textarea>` に昇格、`-> state` autocomplete、state box の first-line + … 表示、PlantUML export の entry/do/exit 記述。

## Base Branch

`fix/ux-review-2026-04-05` (master ではない)。前ブランチの UX brushup 成果物の上に積まれている構造のため、ベースはそちら。master への merge は前ブランチの試用完了後に user 判断。

## Changes (18 commits)

### Feature 1 — cyclic transitions (Tasks 1-6)
- `cadcb89` feat: cyclic field を transition parser/serializer に追加
- `9cf37c1` test: backward-compat assertion を強化
- `689ae5c` refactor: `stripTransitionSuffixes` ヘルパ抽出 (DRY)
- `b57fc6e` feat: 破線 amber + ⟳ で cyclic 描画
- `208d046` refactor: dotted scope creep を revert + `CYCLIC_*` 定数抽出
- `5cc1d0d` refactor: `CYCLIC_*` 定数を file スコープに昇格
- `2fd932f` feat: テーブル cell に ⟳ 前置 (table view)
- `68905fb` feat: プロパティパネルに `@cyclic` チェックボックス
- `3a0cf39` feat: validation E1/E2 + W1 warning (initial/choice/do 欠落)
- `8137098` feat: SVG + PlantUML export に cyclic 反映

### Feature 2 — do editor extension (Tasks 7-11)
- `83a5aa0` feat: parseProps にクォート値対応
- `eebc500` fix: parseProps クォート処理の tidy (L prefix dedup 等)
- `858af1f` refactor: `attachMultilineAutocomplete` ヘルパを action textarea から抽出
- `abfe4f1` feat: `pp-do` を textarea + state autocomplete 化
- `2abd5be` docs: pp-do change-event コメントと formatPropValue policy
- `dac986a` feat: state box で multiline do を first-line + … 表示
- `0304f34` feat: PlantUML export に state entry/do/exit 追加 (multiline 対応)

### Task 12 — regression sweep
- `53a46c7` test: Sprint 1-6 10 OBS + action autocomplete の regression safety net

## Test Plan

- [x] `npx playwright test tests/ux-brushup tests/cyclic-transitions` で **90/90 passing** (36 ux-brushup + 54 cyclic-transitions)
- [x] Sprint 1-6 の 10 OBS fix は regression.spec.js で独立検証
- [x] action autocomplete (2026-04-04 feature) は Task 8 の helper 抽出後も動作
- [ ] 手動確認: `automotive-ecu.sstate` をロード → 任意の遷移を `@cyclic` 化して破線+amber+⟳ を目視
- [ ] 手動確認: `pp-do` でマルチライン入力 (`-> active` autocomplete 等) → 再ロード後も保持
- [ ] 手動確認: PlantUML export → `state idle : do / ...\n... ` 行が出力に含まれる

## Known Deferred Items (次サイクル候補)

以下は本 PR スコープ外、code review で明示 defer:

1. **`buildCandidates(type, prefix)` の dead `prefix` parameter** (Task 8 M1) — 純コスメ、挙動無影響
2. **`savePropField` lift** (Task 9 M3) — border/text/style/round handlers にも `saveActionField` パターンを展開する cleanup
3. **`updateProp` greedy prefix hardening** (Task 9 M4) — `do="reset do=0"` のような稀な edge case

## Spec & Plan (untracked、プロジェクト慣例)

- Design: `docs/superpowers/specs/2026-04-05-cyclic-transitions-design.md` (14KB、本 PR の要件定義)
- Implementation plan: `docs/superpowers/plans/2026-04-05-cyclic-transitions-and-do-editor.md` (2471行、12 task)

## 禁止事項遵守 (CLAUDE.md)

- ✓ master ブランチ未接触 (base は fix/ux-review-2026-04-05)
- ✓ `--no-verify` 未使用
- ✓ amend / force push なし
- ✓ 全18コミットが通常 commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)